### PR TITLE
[@svelteui/core] Propagate changes in value in `Input` component for <svelte:element>

### DIFF
--- a/packages/svelteui-core/src/lib/components/Input/Input.svelte
+++ b/packages/svelteui-core/src/lib/components/Input/Input.svelte
@@ -254,6 +254,12 @@
 		}
 	});
 
+	function onChange() {
+		// the 'this' keyword in this case is the
+		// HTML element provided in prop 'root'
+		value = this.value;
+	}
+
 	// --------------Error Handling-------------------
 	let observable: boolean = false;
 	let err;
@@ -313,6 +319,7 @@ Base component to create custom inputs
 			value={value}
 			use:useActions={use}
 			use:forwardEvents
+			on:change={onChange}
 			{required}
 			{disabled}
 			aria-invalid={invalid}


### PR DESCRIPTION
Propagate `on:change` events in HTML elements used by `svelte:element`, since `bind:value` is not possible (by svelte design)

Example with the NativeSelect and a textarea:
 
https://user-images.githubusercontent.com/25725586/167213413-c1c9ea20-b1a7-498b-9338-0252bf96e686.mp4

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `npm run lint` or just run `npm run repo:prepush` and check to see if it's passing.
