### PR TITLE
[@svelteui/core] Checkbox group

### DIFF
--- a/packages/svelteui-core/src/lib/components/Checkbox/Checkbox.styles.ts
+++ b/packages/svelteui-core/src/lib/components/Checkbox/Checkbox.styles.ts
@@ -7,6 +7,8 @@ export interface CheckboxProps extends DefaultProps {
 	checked: boolean;
 	disabled: boolean;
 	indeterminate: boolean;
+	value: string;
+
 	label: Component | string;
 	radius: SvelteUINumberSize | number;
 	size: SvelteUINumberSize;

--- a/packages/svelteui-core/src/lib/components/Checkbox/Checkbox.svelte
+++ b/packages/svelteui-core/src/lib/components/Checkbox/Checkbox.svelte
@@ -21,6 +21,8 @@
 	export let id: $$CheckboxProps['id'] = randomID();
 	/** Will set the checkbox to disabled state */
 	export let disabled: $$CheckboxProps['disabled'] = false;
+	/** The value of the checkbox */
+	export let value: $$CheckboxProps['value'] = null;
 	/** The value used to set the value of checkbox as checked or unchecked */
 	export let checked: $$CheckboxProps['checked'] = false;
 	/** Sets the checkbox to indetermined state, overrides the checked state */
@@ -81,6 +83,7 @@
 				border: 'transparent',
 				backgroundColor: `$${color}600`,
 				color: '#ffffff',
+				borderRadius: `$${radius}`,
 
 				[`& + .icon-wrapper`]: {
 					opacity: 1,
@@ -121,6 +124,7 @@
 			height: sizes[size],
 			minWidth: sizes[size],
 			minHeight: sizes[size],
+			borderRadius: `$${radius}`,
 			position: 'absolute',
 			zIndex: 1,
 			top: 0,
@@ -173,9 +177,10 @@ A checkbox input component using the theme styles with support for a label and i
 			bind:checked
 			class="input"
 			class:disabled
-			{disabled}
-			{id}
 			type="checkbox"
+			{disabled}
+			{value}
+			{id}
 		/>
 		<ThemeIcon class="icon-wrapper" {size}>
 			<slot>

--- a/packages/svelteui-core/src/lib/components/Checkbox/CheckboxGroup/CheckboxGroup.styles.ts
+++ b/packages/svelteui-core/src/lib/components/Checkbox/CheckboxGroup/CheckboxGroup.styles.ts
@@ -1,0 +1,14 @@
+import type { CSS, DefaultProps, SvelteUIColor, SvelteUINumberSize } from '$lib/styles';
+
+export interface CheckboxGroupProps extends DefaultProps {
+	color: SvelteUIColor;
+	items: { label: string; value: string }[];
+	value: string[];
+	label: string;
+	size: SvelteUINumberSize;
+	radius: SvelteUINumberSize | number;
+	direction: 'row' | 'column';
+	align: CSS['alignItems'];
+	spacing: SvelteUINumberSize;
+	wrapperProps: { [key: string]: any };
+}

--- a/packages/svelteui-core/src/lib/components/Checkbox/CheckboxGroup/CheckboxGroup.svelte
+++ b/packages/svelteui-core/src/lib/components/Checkbox/CheckboxGroup/CheckboxGroup.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+	import InputWrapper from '../../InputWrapper/InputWrapper.svelte';
+	import Group from '../../Group/Group.svelte';
+    import Checkbox from '../Checkbox.svelte';
+	import type { CheckboxGroupProps as $$CheckboxGroupProps } from './CheckboxGroup.styles';
+
+	/** Used for custom classes to be applied to the checkbox group e.g. Tailwind classes */
+	export let className: $$CheckboxGroupProps['className'] = '';
+	export { className as class };
+	/** Css prop for custom theming the component */
+	export let override: $$CheckboxGroupProps['override'] = {};
+	/** Checkbox group color  when activated from theme */
+	export let color: $$CheckboxGroupProps['color'] = 'gray';
+	/** The values of the currently selected checkboxes */
+	export let items: $$CheckboxGroupProps['items'] = [];
+	/** The values of the currently selected checkboxes */
+	export let value: $$CheckboxGroupProps['value'] = [];
+	/** The label of the checkbox */
+	export let label: $$CheckboxGroupProps['label'] = null;
+	/** Predefined checkbox size */
+	export let size: $$CheckboxGroupProps['size'] = 'md';
+    /** Predefined checkbox radius */
+	export let radius: $$CheckboxGroupProps['radius'] = 'sm';
+	/** Predefined checkbox spacing between checkboxes in horizontal orientation */
+	export let direction: $$CheckboxGroupProps['direction'] = 'row';
+	/** Predefined checkbox spacing between checkboxes in horizontal orientation */
+	export let align: $$CheckboxGroupProps['align'] = 'flex-start';
+	/** Predefined checkbox spacing between checkboxes in horizontal orientation */
+	export let spacing: $$CheckboxGroupProps['spacing'] = 'md';
+	/** The props to pass to the wrapper component */
+	export let wrapperProps: $$CheckboxGroupProps['wrapperProps'] = {};
+
+    function onChanged(item, el) {        
+        if (el.checked) value = [...value, item];
+        else value = value.filter(val => val !== item);
+    }
+</script>
+
+<!--
+@component
+**UNSTABLE**: new API, yet to be vetted.
+
+A checkbox group component using the theme styles and builds a set of checkboxes according to
+the items passed.
+	
+@see https://svelteui-docs.vercel.app/docs/core/checkbox
+@example
+    ```svelte
+    <CheckboxGroup bind:value items={items} />
+    <CheckboxGroup label={"Choose your favorite framework"} description={"Choose carefuly"} bind:value={value} items={items} />
+    <CheckboxGroup bind:value={value} items={items} direction={'column'}/>
+    ```
+-->
+
+<InputWrapper class="{className}" {label} {override} {size} {...wrapperProps} {...$$restProps}>
+    <Group {direction} {spacing} {align}>
+        {#each items as item}
+            <Checkbox
+                label={item.label}
+                value={item.value}
+                checked={value.includes(item.value)}
+                {radius}
+                {size}
+                {color}
+                on:change={(e) => onChanged(item.value, e.target)}
+            />
+        {/each}
+    </Group>
+</InputWrapper>

--- a/packages/svelteui-core/src/lib/components/Checkbox/index.ts
+++ b/packages/svelteui-core/src/lib/components/Checkbox/index.ts
@@ -1,2 +1,4 @@
 export { default as Checkbox } from './Checkbox.svelte';
+export { default as CheckboxGroup } from './CheckboxGroup/CheckboxGroup.svelte';
 export * as CheckboxStyles from './Checkbox.styles';
+export * as CheckboxGroupStyles from './CheckboxGroup/CheckboxGroup.styles';

--- a/packages/svelteui-core/src/lib/components/Group/Group.svelte
+++ b/packages/svelteui-core/src/lib/components/Group/Group.svelte
@@ -3,7 +3,6 @@
 	import { GroupErrors } from './Group.errors';
 	import Box from '../Box/Box.svelte';
 	import Error from '$lib/internal/errors/Error.svelte';
-	import type { CSS } from '$lib/styles';
 	import type { GroupProps as $$GroupProps } from './Group.styles';
 
 	/** Used for custom classes to be applied to the button e.g. Tailwind classes */

--- a/packages/svelteui-core/src/lib/components/InputWrapper/InputWrapper.svelte
+++ b/packages/svelteui-core/src/lib/components/InputWrapper/InputWrapper.svelte
@@ -13,9 +13,9 @@
 	/** Input label, displayed before input */
 	export let label: $$InputWrapperProps['label'] = 'label';
 	/** Input description, displayed after label */
-	export let description: $$InputWrapperProps['description'] = 'description';
+	export let description: $$InputWrapperProps['description'] = null;
 	/** Displays error message after input */
-	export let error: $$InputWrapperProps['error'] = 'error';
+	export let error: $$InputWrapperProps['error'] = null;
 	/** Adds red asterisk on the right side of label */
 	export let required: $$InputWrapperProps['required'] = false;
 	/** Props spread to label element */


### PR DESCRIPTION
Added checkbox group component.

**Decision taken**:
- It differs from the Mantine approach, for example, where the checkbox instead of being passed as slots, are built by the CheckboxGroup component, since this is the only way for it to access its children props.
- Due to the existence of a known limitation of svelte in the usage of `groups` in checkboxes - https://github.com/sveltejs/svelte/issues/2308 - another approach was taken (using the `on:change` and managing the checked entities inside CheckboxGroup)

https://user-images.githubusercontent.com/25725586/167257151-91da4673-f9a0-4627-bb63-2e8a539a8562.mp4

Example Code:
```
<script>
       const items = [
		{
			value: "react",
			label: "React"
		},
		{
			value: "vue",
			label: "Vue"
		},
		{
			value: "svelte",
			label: "Svelte"
		}
	];
	let value = ["svelte"];
	$: console.log("value", value);
</script>

<CheckboxGroup label={"Choose your favorite framework"} description={"Choose carefuly"} bind:value={value} items={items} />
<div>Value contents: {JSON.stringify(value)}</div>

<div style="margin-top: 30px"></div>
<CheckboxGroup label={"Now with spacing"} bind:value={value} items={items} spacing={'xs'} error={"Something went wrong, oops"} />

<div style="margin-top: 30px"></div>
<CheckboxGroup label={"Now with direction 'column'"}  bind:value={value} items={items} direction={'column'}/>

```

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `npm run lint` or just run `npm run repo:prepush` and check to see if it's passing.
