### PR TITLE
[docs] Port svelteui/core components from previous docs

### DIFF
--- a/docs/src/pages/core/action-icon.md
+++ b/docs/src/pages/core/action-icon.md
@@ -10,6 +10,148 @@ source: 'svelte-core/src/lib/components/ActionIcon/ActionIcon.svelte'
 docs: 'core/action-icon.md'
 ---
 
-import { CodeBlock, Heading } from 'components'
+<script lang="ts">
+    import { ActionIcon, CloseButton, SimpleGrid } from '@svelteuidev/core';
+    import { GithubLogo } from "radix-icons-svelte";
+    import { Heading, Preview } from 'components';
+
+    const action = `
+        <script>
+            import { ActionIcon } from '@svelteuidev/core';
+            import { GithubLogo } from "radix-icons-svelte";
+        <\/script>
+
+        <ActionIcon><GithubLogo size={16} \/><\/ActionIcon>
+    `;
+    const variantActions = `
+        <script>
+            import { ActionIcon } from '@svelteuidev/core';
+            import { GithubLogo } from "radix-icons-svelte";
+        <\/script>
+
+        <ActionIcon color="blue" variant="hover"><GithubLogo size={16} \/><\/ActionIcon>
+        <ActionIcon color="blue" variant="default"><GithubLogo size={16} \/><\/ActionIcon>
+        <ActionIcon color="blue" variant="transparent"><GithubLogo size={16} \/><\/ActionIcon>
+        <ActionIcon color="blue" variant="filled"><GithubLogo size={16} \/><\/ActionIcon>
+        <ActionIcon color="blue" variant="light"><GithubLogo size={16} \/><\/ActionIcon>
+        <ActionIcon color="blue" variant="outline"><GithubLogo size={16} \/><\/ActionIcon>
+    `;
+    const colorActions = `
+        <script>
+            import { ActionIcon } from '@svelteuidev/core';
+            import { GithubLogo } from "radix-icons-svelte";
+        <\/script>
+
+        <ActionIcon color="red"><GithubLogo size={16} \/><\/ActionIcon>
+        <ActionIcon color="green"><GithubLogo size={16} \/><\/ActionIcon>
+        <ActionIcon color="teal"><GithubLogo size={16} \/><\/ActionIcon>
+        <ActionIcon color="gray"><GithubLogo size={16} \/><\/ActionIcon>
+        <ActionIcon color="blue"><GithubLogo size={16} \/><\/ActionIcon>
+        <ActionIcon color="yellow"><GithubLogo size={16} \/><\/ActionIcon>
+    `;
+    const sizeActions = `
+        <script>
+            import { ActionIcon } from '@svelteuidev/core';
+            import { GithubLogo } from "radix-icons-svelte";
+        <\/script>
+
+        <ActionIcon radius="lg" color="blue" variant="filled"><GithubLogo size={16} \/><\/ActionIcon> // -> theme predefined large radius
+        <ActionIcon radius={10} color="blue" variant="filled"><GithubLogo size={16} \/><\/ActionIcon> // -> { borderRadius: '10px' }
+        <ActionIcon size="sm" color="blue" variant="filled"><GithubLogo size={16} \/><\/ActionIcon> // -> predefined small size
+        <ActionIcon size={50} color="blue" variant="filled"><GithubLogo size={16} \/><\/ActionIcon> // -> { width: '50px', height: '50px' }
+    `;
+    const closeButton = `
+        <script>
+            import { closeButton } from '@svelteuidev/core';
+        <\/script>
+
+        <CloseButton variant="filled" \/>
+        <CloseButton size="xl" iconSize={20} variant="filled" \/>
+    `;
+    const accessibility = `
+        <script>
+            import { ActionIcon } from '@svelteuidev/core';
+            import { GithubLogo } from "radix-icons-svelte";
+        <\/script>
+
+        <ActionIcon><GithubLogo size={16} \/><\/ActionIcon> // -> not visible to screen reader
+        <ActionIcon title="Settings"><GithubLogo size={16} \/><\/ActionIcon> // -> ok
+        <ActionIcon aria-label="Settings"><GithubLogo size={16} \/><\/ActionIcon> // -> ok
+    `;
+</script>
 
 <Heading />
+
+## Usage
+
+ActionIcon accepts anything as child. It **does not control icon size**, the user must specify it manually on the icon component to match ActionIcon size. For example, in radix-icons-svelte you can use size prop:
+
+<Preview code={action}>
+    <ActionIcon><GithubLogo size={16} /></ActionIcon>
+</Preview>
+
+### Variants
+
+ActionIcon has 6 variants: `hover`, `default`, `transparent`, `filled`, `light` and `outline`:
+
+<Preview code={variantActions}>
+    <SimpleGrid cols={6}>
+        <ActionIcon color="blue" variant="hover"><GithubLogo size={16} /></ActionIcon>
+        <ActionIcon color="blue" variant="default"><GithubLogo size={16} /></ActionIcon>
+        <ActionIcon color="blue" variant="transparent"><GithubLogo size={16} /></ActionIcon>
+        <ActionIcon color="blue" variant="filled"><GithubLogo size={16} /></ActionIcon>
+        <ActionIcon color="blue" variant="light"><GithubLogo size={16} /></ActionIcon>
+        <ActionIcon color="blue" variant="outline"><GithubLogo size={16} /></ActionIcon>
+    </SimpleGrid>
+</Preview>
+
+### Color
+
+ActionIcon supports all colors from [theme.colors](theming/default-theme):
+
+<Preview code={colorActions}>
+    <SimpleGrid cols={6}>
+        <ActionIcon color="red"><GithubLogo size={16} /></ActionIcon>
+        <ActionIcon color="green"><GithubLogo size={16} /></ActionIcon>
+        <ActionIcon color="teal"><GithubLogo size={16} /></ActionIcon>
+        <ActionIcon color="gray"><GithubLogo size={16} /></ActionIcon>
+        <ActionIcon color="blue"><GithubLogo size={16} /></ActionIcon>
+        <ActionIcon color="yellow"><GithubLogo size={16} /></ActionIcon>
+    </SimpleGrid>
+</Preview>
+
+### Size and radius
+
+Control button width and height with `size` and border-radius with `radius`. Both props have predefined values: `xs`, `sm`, `md`, `lg`, `xl`. Alternatively, use a number to set radius or size in px:
+
+<Preview code={sizeActions}>
+    <SimpleGrid cols={4}>
+        <ActionIcon color="blue" radius="lg" variant="filled"><GithubLogo size={16} /></ActionIcon>
+        <ActionIcon color="blue" radius={10} variant="filled"><GithubLogo size={16} /></ActionIcon>
+        <ActionIcon color="blue" size="sm" variant="filled"><GithubLogo size={16} /></ActionIcon>
+        <ActionIcon color="blue" size={50} variant="filled"><GithubLogo size={16} /></ActionIcon>
+    </SimpleGrid>
+</Preview>
+
+## Close button
+
+CloseButton is a pre-made ActionIcon with close icon, it will be used in all other components: Popover, Modal, Notification, etc. Component accepts the same props as ActionIcon with additional `iconSize` prop to control icon width and height:
+
+<Preview code={closeButton}>
+    <SimpleGrid cols={2}>
+        <CloseButton variant="filled" />
+        <CloseButton size="xl" iconSize={20} variant="filled" />
+    </SimpleGrid>
+</Preview>
+
+## Accessibility
+
+ActionIcon renders a regular `button` element. Set `title` or `aria-label` props for screen reader support:
+
+<Preview code={accessibility}>
+    <SimpleGrid cols={3}>
+        <ActionIcon><GithubLogo size={16} /></ActionIcon>
+        <ActionIcon title="Settings"><GithubLogo size={16} /></ActionIcon>
+        <ActionIcon aria-label="Settings"><GithubLogo size={16} /></ActionIcon>
+    </SimpleGrid>
+</Preview>

--- a/docs/src/pages/core/button.md
+++ b/docs/src/pages/core/button.md
@@ -10,7 +10,7 @@ source: 'svelteui-core/src/lib/components/Button/Button.svelte'
 docs: 'core/button.md'
 ---
 
-<script>
+<script lang="ts">
     import { ActionIcon, Button } from '@svelteuidev/core';
     import { Heading, Preview } from 'components'
 

--- a/docs/src/pages/core/button.md
+++ b/docs/src/pages/core/button.md
@@ -12,6 +12,7 @@ docs: 'core/button.md'
 
 <script lang="ts">
     import { ActionIcon, Button, SimpleGrid } from '@svelteuidev/core';
+    import { GithubLogo } from "radix-icons-svelte";
     import { Heading, Preview } from 'components'
 
     const simpleButtons = `
@@ -60,12 +61,13 @@ docs: 'core/button.md'
     `;
     const customizeButtons = `
         <script>
-            import { ActionIcon, Button } from '@svelteuidev/core';
+            import { Button } from '@svelteuidev/core';
+            import { GithubLogo } from "radix-icons-svelte";
         <\/script>
 
         <Button override={{ backgroundColor: 'red' }} variant='outline'>Click Me<\/Button>
         <Button>
-            <ActionIcon \/>Click Me
+            <GithubLogo size={16} \/> I love open source!
         <\/Button>
     `;
     const sizeButtons = `
@@ -181,7 +183,7 @@ You can change styles of any element in button component with `override` prop to
     <SimpleGrid cols={2}>
         <Button override={{ backgroundColor: 'red' }} variant='outline'>Click Me</Button>
         <Button>
-            <ActionIcon />Click Me
+            <GithubLogo size={16} /> I love open source!
         </Button>
     </SimpleGrid>
 </Preview>

--- a/docs/src/pages/core/button.md
+++ b/docs/src/pages/core/button.md
@@ -11,7 +11,7 @@ docs: 'core/button.md'
 ---
 
 <script lang="ts">
-    import { ActionIcon, Button } from '@svelteuidev/core';
+    import { ActionIcon, Button, SimpleGrid } from '@svelteuidev/core';
     import { Heading, Preview } from 'components'
 
     const simpleButtons = `
@@ -108,8 +108,10 @@ docs: 'core/button.md'
 ## Usage
 
 <Preview code={simpleButtons}>
-    <Button />
-    <Button>Click me!</Button>
+    <SimpleGrid cols={2}>
+        <Button />
+        <Button>Click me!</Button>
+    </SimpleGrid>
 </Preview>
 
 ### Variants
@@ -117,9 +119,11 @@ docs: 'core/button.md'
 Button supports the following variants: `default`, `subtle`, `white`, `gradient`, `filled`, `light` and `outline`. Default Button color is `theme.blue600`, to change color and variant pass color and variant props:
 
 <Preview code={variantButtons}>
-    <Button color="red" />
-    <Button variant="outline"/>
-    <Button variant="filled"/>
+    <SimpleGrid cols={3}>
+        <Button color="red" />
+        <Button variant="outline"/>
+        <Button variant="filled"/>
+    </SimpleGrid>
 </Preview>
 
 #### Gradient variant
@@ -132,11 +136,13 @@ To use gradient as Button background:
     * `deg` is linear gradient degree
 
 <Preview code={gradientButtons}>
-    <Button variant='gradient'>Default</Button>
-    <Button variant='gradient' gradient={{from: 'teal', to: 'green', deg: 105}}>Lime Green</Button>
-    <Button variant='gradient' gradient={{from: 'teal', to: 'blue', deg: 60}}>Teal Blue</Button>
-    <Button variant='gradient' gradient={{from: 'orange', to: 'red', deg: 45}}>Orange red</Button>
-    <Button variant='gradient' gradient={{from: 'grape', to: 'pink', deg: 35}}>Grape Pink</Button>
+    <SimpleGrid cols={5}>
+        <Button variant='gradient'>Default</Button>
+        <Button variant='gradient' gradient={{from: 'teal', to: 'green', deg: 105}}>Lime Green</Button>
+        <Button variant='gradient' gradient={{from: 'teal', to: 'blue', deg: 60}}>Teal Blue</Button>
+        <Button variant='gradient' gradient={{from: 'orange', to: 'red', deg: 45}}>Orange red</Button>
+        <Button variant='gradient' gradient={{from: 'grape', to: 'pink', deg: 35}}>Grape Pink</Button>
+    </SimpleGrid>
 </Preview>
 
 #### White variant
@@ -144,8 +150,10 @@ To use gradient as Button background:
 White is a variant in which button background color is always white (both in light and dark theme) and `color` is controlled with color prop:
 
 <Preview code={whiteButtons}>
-    <Button variant="white">Click Me</Button>
-    <Button variant="white" color="red">I am red</Button>
+    <SimpleGrid cols={2}>
+        <Button variant="white">Click Me</Button>
+        <Button variant="white" color="red">I am red</Button>
+    </SimpleGrid>
 </Preview>
 
 ### Loading state
@@ -159,8 +167,10 @@ You can control loading state and [Loader](core/loader) component with following
 * `loaderProps` - props spread to Loader component, you can choose loader type, size and any other [supported](core/loader) prop
 
 <Preview code={loadingButtons}>
-    <Button loading={true}>I am loading</Button>
-    <Button loading={true} loaderPosition={"right"}>I am loading on the right</Button>
+    <SimpleGrid cols={2}>
+        <Button loading={true}>I am loading</Button>
+        <Button loading={true} loaderPosition={"right"}>I am loading on the right</Button>
+    </SimpleGrid>
 </Preview>
 
 ### Customize
@@ -168,10 +178,12 @@ You can control loading state and [Loader](core/loader) component with following
 You can change styles of any element in button component with `override` prop to match your design requirements. See [Theming](theming/utilities) for more information about how to customize the styles of the component.
 
 <Preview code={loadingButtons}>
-    <Button override={{ backgroundColor: 'red' }} variant='outline'>Click Me</Button>
-    <Button>
-        <ActionIcon />Click Me
-    </Button>
+    <SimpleGrid cols={2}>
+        <Button override={{ backgroundColor: 'red' }} variant='outline'>Click Me</Button>
+        <Button>
+            <ActionIcon />Click Me
+        </Button>
+    </SimpleGrid>
 </Preview>
 
 ### Size and radius
@@ -179,18 +191,22 @@ You can change styles of any element in button component with `override` prop to
 Control button font-size, height and padding with `size` and border-radius with `radius` props. Both props have predefined values: `xs`, `sm`, `md`, `lg`, `xl`. Alternatively, you can use a number to set radius in px:
 
 <Preview code={sizeButtons}>
-    <Button radius="lg" />
-    <Button radius={10} />
-    <Button size="sm" />
-    <Button size="lg" />
+    <SimpleGrid cols={4}>
+        <Button radius="lg" />
+        <Button radius={10} />
+        <Button size="sm" />
+        <Button size="lg" />
+    </SimpleGrid>
 </Preview>
 
 ### Compact
 
 <Preview code={compactButtons}>
-    <Button compact>Click Me</Button>
-    <Button variant='outline' compact>Click Me</Button>
-    <Button variant='default' compact>Click Me</Button>
+    <SimpleGrid cols={3}>
+        <Button compact>Click Me</Button>
+        <Button variant='outline' compact>Click Me</Button>
+        <Button variant='default' compact>Click Me</Button>
+    </SimpleGrid>
 </Preview>
 
 ### Full width and overflow

--- a/docs/src/pages/core/button.md
+++ b/docs/src/pages/core/button.md
@@ -10,6 +10,201 @@ source: 'svelteui-core/src/lib/components/Button/Button.svelte'
 docs: 'core/button.md'
 ---
 
-import { CodeBlock, Heading } from 'components'
+<script>
+    import { ActionIcon, Button } from '@svelteuidev/core';
+    import { Heading, Preview } from 'components'
+
+    const simpleButtons = `
+        <script>
+            import { Button } from '@svelteuidev/core';
+        <\/script>
+
+        <Button \/>
+        <Button>Click me!<\/Button>
+    `;
+    const variantButtons = `
+        <script>
+            import { Button } from '@svelteuidev/core';
+        <\/script>
+
+        <Button color="red" \/>
+        <Button variant="outline"\/>
+        <Button variant="filled"\/>
+    `;
+    const gradientButtons = `
+        <script>
+            import { Button } from '@svelteuidev/core';
+        <\/script>
+
+        <Button variant='gradient'>Default<\/Button>
+        <Button variant='gradient' gradient={{from: 'teal', to: 'green', deg: 105}}>Lime Green<\/Button>
+        <Button variant='gradient' gradient={{from: 'teal', to: 'blue', deg: 60}}>Teal Blue<\/Button>
+        <Button variant='gradient' gradient={{from: 'orange', to: 'red', deg: 45}}>Orange red<\/Button>
+        <Button variant='gradient' gradient={{from: 'grape', to: 'pink', deg: 35}}>Grape Pink<\/Button>
+    `;
+    const whiteButtons = `
+        <script>
+            import { Button } from '@svelteuidev/core';
+        <\/script>
+
+        <Button variant="white">Click Me<\/Button>
+        <Button variant="white" color="red">I am red<\/Button>
+    `;
+    const loadingButtons = `
+        <script>
+            import { Button } from '@svelteuidev/core';
+        <\/script>
+
+        <Button loading={true}>I am loading<\/Button>
+        <Button loading={true} loaderPosition={"right"}>I am loading on the right<\/Button>
+    `;
+    const customizeButtons = `
+        <script>
+            import { ActionIcon, Button } from '@svelteuidev/core';
+        <\/script>
+
+        <Button override={{ backgroundColor: 'red' }} variant='outline'>Click Me<\/Button>
+        <Button>
+            <ActionIcon \/>Click Me
+        <\/Button>
+    `;
+    const sizeButtons = `
+        <script>
+            import { Button } from '@svelteuidev/core';
+        <\/script>
+
+        <Button radius="lg" \/> // -> theme predefined large radius
+        <Button radius={10} \/> // -> ( borderRadius: '10px' )
+        <Button size="sm" \/> // -> predefined small size
+        <Button size="lg" \/> // -> predefined large size
+    `;
+    const compactButtons = `
+        <script>
+            import { Button } from '@svelteuidev/core';
+        <\/script>
+
+        <Button compact>Click Me<\/Button>
+        <Button variant='outline' compact>Click Me<\/Button>
+        <Button variant='default' compact>Click Me<\/Button>
+    `;
+    const fullsizeButtons = `
+        <script>
+            import { Button } from '@svelteuidev/core';
+        <\/script>
+
+        <Button fullSize>Click Me<\/Button>
+    `;
+    const rootButtons = `
+        <script>
+            import { Button } from '@svelteuidev/core';
+        <\/script>
+
+        <Button href="https://github.com/svelteuidev/svelteui">I go to svelteuidev/svelteui<\/Button>
+    `;
+</script>
 
 <Heading />
+
+## Usage
+
+<Preview code={simpleButtons}>
+    <Button />
+    <Button>Click me!</Button>
+</Preview>
+
+### Variants
+
+Button supports the following variants: `default`, `subtle`, `white`, `gradient`, `filled`, `light` and `outline`. Default Button color is `theme.blue600`, to change color and variant pass color and variant props:
+
+<Preview code={variantButtons}>
+    <Button color="red" />
+    <Button variant="outline"/>
+    <Button variant="filled"/>
+</Preview>
+
+#### Gradient variant
+
+To use gradient as Button background:
+
+* set `variant` prop to `gradient`
+* set `gradient` prop to `(from: 'color-from', to: 'color-to', deg: 135)`, where
+    * `color-from` and `color-to` are color from `theme.colors`
+    * `deg` is linear gradient degree
+
+<Preview code={gradientButtons}>
+    <Button variant='gradient'>Default</Button>
+    <Button variant='gradient' gradient={{from: 'teal', to: 'green', deg: 105}}>Lime Green</Button>
+    <Button variant='gradient' gradient={{from: 'teal', to: 'blue', deg: 60}}>Teal Blue</Button>
+    <Button variant='gradient' gradient={{from: 'orange', to: 'red', deg: 45}}>Orange red</Button>
+    <Button variant='gradient' gradient={{from: 'grape', to: 'pink', deg: 35}}>Grape Pink</Button>
+</Preview>
+
+#### White variant
+
+White is a variant in which button background color is always white (both in light and dark theme) and `color` is controlled with color prop:
+
+<Preview code={whiteButtons}>
+    <Button variant="white">Click Me</Button>
+    <Button variant="white" color="red">I am red</Button>
+</Preview>
+
+### Loading state
+
+Button supports loading state. In this state [Loader](core/loader) component replaces left or right icon, button becomes disabled and white or dark overlay is added.
+
+You can control loading state and [Loader](core/loader) component with following props:
+
+* `loading` - enable loading state
+* `loaderPosition` - Loader position relative to button label, either `right` or `left`
+* `loaderProps` - props spread to Loader component, you can choose loader type, size and any other [supported](core/loader) prop
+
+<Preview code={loadingButtons}>
+    <Button loading={true}>I am loading</Button>
+    <Button loading={true} loaderPosition={"right"}>I am loading on the right</Button>
+</Preview>
+
+### Customize
+
+You can change styles of any element in button component with `override` prop to match your design requirements. See [Theming](theming/utilities) for more information about how to customize the styles of the component.
+
+<Preview code={loadingButtons}>
+    <Button override={{ backgroundColor: 'red' }} variant='outline'>Click Me</Button>
+    <Button>
+        <ActionIcon />Click Me
+    </Button>
+</Preview>
+
+### Size and radius
+
+Control button font-size, height and padding with `size` and border-radius with `radius` props. Both props have predefined values: `xs`, `sm`, `md`, `lg`, `xl`. Alternatively, you can use a number to set radius in px:
+
+<Preview code={sizeButtons}>
+    <Button radius="lg" />
+    <Button radius={10} />
+    <Button size="sm" />
+    <Button size="lg" />
+</Preview>
+
+### Compact
+
+<Preview code={compactButtons}>
+    <Button compact>Click Me</Button>
+    <Button variant='outline' compact>Click Me</Button>
+    <Button variant='default' compact>Click Me</Button>
+</Preview>
+
+### Full width and overflow
+
+Button can take full width of container if you set `fullSize` prop. If button is too large for its container, overflow content will be hidden:
+
+<Preview code={fullsizeButtons}>
+     <Button fullSize>Click Me</Button>
+</Preview>
+
+### Change root element
+
+You can use `Button` component both as `button` or `a` elements. The component's root element can be changed by adding the `href` prop. Adding the `external` prop will set the target attribute to blank:
+
+<Preview code={rootButtons}>
+    <Button href="https://github.com/svelteuidev/svelteui">I go to svelteuidev/svelteui</Button>
+</Preview>

--- a/docs/src/pages/core/code.md
+++ b/docs/src/pages/core/code.md
@@ -10,6 +10,65 @@ source: 'svelteui-core/src/lib/components/Code/Code.svelte'
 docs: 'core/code.md'
 ---
 
-import { CodeBlock, Heading } from 'components'
+<script lang="ts">
+    import { Code } from '@svelteuidev/core';
+    import { Heading, Preview } from 'components';
+
+    const code = `
+        <script>
+            import { Code } from '@svelteuidev/core';
+        <\/script>
+
+        <Code>This code will be inline<\/Code>
+    `;
+    const blockCode = `
+        <script>
+            import { Code } from '@svelteuidev/core';
+        <\/script>
+
+        <Code block copy>This code will be in block and you can copy<\/Code>
+    `;
+    const colorCode = `
+        <script>
+            import { Code } from '@svelteuidev/core';
+        <\/script>
+
+        <Code color="red">This code is red<\/Code>
+        <Code color="teal">This code is teal<\/Code>
+        <Code color="blue">This code is blue<\/Code>
+    `;
+</script>
 
 <Heading />
+
+## Usage
+
+By default the Code component renders inline `code` html element:
+
+<Preview code={code}>
+    <Code>This code will be inline</Code>
+</Preview>
+
+### Block code
+
+To render code in `pre` element pass block prop to Code component. It is also possible to allow copying the code to the clipboard with the prop `copy`:
+
+<Preview code={blockCode}>
+    <Code block copy message={"This code will be in block and you can copy"}>
+        This code will be in block and you can copy
+    </Code>
+</Preview>
+
+### Custom color
+
+By default, code has gray color, you can change it to any color from [theme colors](theming/default-theme.md):
+
+<Preview code={colorCode}>
+    <Code color="red">This code is red</Code>
+    <Code color="teal">This code is teal</Code>
+    <Code color="blue">This code is blue</Code>
+</Preview>
+
+### Syntax highlight
+
+For syntax highlight consult the [prism package](others/prism).

--- a/docs/src/pages/core/image.md
+++ b/docs/src/pages/core/image.md
@@ -10,6 +10,212 @@ source: 'svelte-core/src/lib/components/Image/Image.svelte'
 docs: 'core/image.md'
 ---
 
-import { CodeBlock, Heading } from 'components'
+<script lang="ts">
+    import { BackgroundImage, Image, SimpleGrid, Text } from '@svelteuidev/core';
+    import { Heading, Preview } from 'components';
+
+    const url = "https://images.unsplash.com/photo-1511216335778-7cb8f49fa7a3?auto=format&fit=crop&w=720&q=80";
+    const doggo = "https://images.unsplash.com/photo-1627552245715-77d79bbf6fe2?auto=format&fit=crop&w=640&q=80";
+
+    const image = `
+        <script>
+            import { Image } from '@svelteuidev/core';
+        <\/script>
+
+        <Image
+            radius="md"
+            src={url}
+            alt="Random unsplash image"
+        \/>
+    `;
+    const sizeImage = `
+        <script>
+            import { Image } from '@svelteuidev/core';
+        <\/script>
+
+        <Image
+            width={200}
+            height={80}
+            src={url}
+        \/>
+        <Image
+            width={200}
+            height={80}
+            fit="contain"
+            src={url}
+        \/>
+        <Image
+            height={80}
+            src={url}
+        \/>
+    `;
+    const placeholderImage = `
+        <script>
+            import { Image } from '@svelteuidev/core';
+        <\/script>
+
+        <Image
+            width={200}
+            height={120}
+            src={null}
+            alt="Without placeholder"
+        \/>
+        <Image
+            width={200}
+            height={120}
+            src={null}
+            alt="With default placeholder"
+            usePlaceholder
+        \/>
+    `;
+    const captionImage = `
+        <script>
+            import { Image } from '@svelteuidev/core';
+        <\/script>
+
+        <Image
+            radius="md"
+            src={doggo}
+            alt="Random unsplash image"
+            caption="My dog begging for treats"
+        \/>
+    `;
+    const radiusImage = `
+        <script>
+            import { Image } from '@svelteuidev/core';
+        <\/script>
+
+        <Image radius={0} src={doggo} \/>
+        <Image radius={"lg"} src={doggo} \/>
+        <Image radius={10} src={doggo} \/>
+    `;
+    const backgroundImage = `
+        <script>
+            import { BackgroundImage, Text } from '@svelteuidev/core';
+        <\/script>
+
+        <BackgroundImage
+            src={url}
+            radius="sm"
+        >
+            <Text color="#fff">
+                BackgroundImage component can be used to add any content on image. It is useful for hero
+                headers and other similar sections
+            <\/Text>
+        <\/BackgroundImage>
+    `;
+</script>
 
 <Heading />
+
+## Usage
+
+Image component is a wrapper around img element with option to change object fit, radius and placeholder:
+
+<Preview code={image}>
+    <Image
+      radius="md"
+      src={url}
+      alt="Random unsplash image"
+    />
+</Preview>
+
+### Width and height
+
+In the example above, the image takes 100% of width of its container and height is calculated dynamically based on image proportion. To change this behavior, set image width and height to define image size.
+
+Note that if image proportions do not match given width and height, some parts will be cut out. In case you want to show image in its original proportions but fitted in current width and height set `fit="contain"`:
+
+<Preview code={sizeImage}>
+    <SimpleGrid cols={3}>
+        <Image
+            width={200}
+            height={80}
+            src={url}
+        />
+        <Image
+            width={200}
+            height={80}
+            fit="contain"
+            src={url}
+        />
+        <Image
+            height={80}
+            src={url}
+        />
+    </SimpleGrid>
+</Preview>
+
+### Placeholder
+
+By default the placeholders image is disabled. Image placeholder is displayed in these cases:
+
+* `usePlaceholder` prop is set to true
+* Image is currently loading
+* Error occurred during image loading (e.g. broken link)
+* Image did not receive `src` prop
+
+Placeholder size is determined by width and height props. Placeholder is centered vertically and horizontally across provided width and height.
+
+<Preview code={placeholderImage}>
+    <SimpleGrid cols={2}>
+        <Image
+            width={200}
+            height={120}
+            src={null}
+            alt="Without placeholder"
+        />
+        <div style="width: 200px; height: 120px">
+            <Image
+                width={200}
+                height={120}
+                src={null}
+                alt="With default placeholder"
+                usePlaceholder
+            />
+        </div>
+    </SimpleGrid>
+</Preview>
+
+### With caption
+
+You can add figcaption to an image with `caption` prop:
+
+<Preview code={captionImage}>
+    <SimpleGrid cols={1}>
+        <Image
+            radius="md"
+            src={doggo}
+            alt="Random unsplash image"
+            caption="My dog begging for treats"
+        />
+    </SimpleGrid>
+</Preview>
+
+### Radius
+
+Radius is applied both to image and placeholder. Radius has predefined values: `xs`, `sm`, `md`, `lg`, `xl`. Alternatively, you can use a number to set border-radius in px:
+
+<Preview code={radiusImage}>
+    <SimpleGrid cols={3}>
+        <Image radius={0} src={doggo} />
+        <Image radius={"lg"} src={doggo} />
+        <Image radius={10} src={doggo} />
+    </SimpleGrid>
+</Preview>
+
+### BackgroundImage component
+
+Use BackgroundImage component when you need to display image below any content. Component sets `background-image` to given `src`, `background-size` to `cover` and `background-position` to `center`. It can be used for cards, hero headers and similar components:
+
+<Preview code={backgroundImage}>
+    <BackgroundImage
+        src={url}
+        radius="sm"
+    >
+        <Text color="#fff">
+        BackgroundImage component can be used to add any content on image. It is useful for hero
+        headers and other similar sections
+        </Text>
+    </BackgroundImage>
+</Preview>

--- a/docs/src/pages/core/loader.md
+++ b/docs/src/pages/core/loader.md
@@ -10,6 +10,63 @@ source: 'svelte-core/src/lib/components/Loader/Loader.svelte'
 docs: 'core/loader.md'
 ---
 
-import { CodeBlock, Heading } from 'components'
+<script lang="ts">
+    import { Loader, SimpleGrid } from '@svelteuidev/core';
+    import { Heading, Preview } from 'components';
+
+    const loader = `
+        <script>
+            import { Loader } from '@svelteuidev/core';
+        <\/script>
+
+        <Loader \/>
+    `;
+    const variantLoaders = `
+        <script>
+            import { Loader } from '@svelteuidev/core';
+        <\/script>
+
+        <Loader variant="circle" \/>
+        <Loader variant="dots" \/>
+        <Loader variant="bars" \/>
+    `;
+    const sizeLoaders = `
+        <script>
+            import { Loader } from '@svelteuidev/core';
+        <\/script>
+
+        <Loader size="lg" \/>
+        <Loader size={50} \/>
+    `;
+</script>
 
 <Heading />
+
+## Usage
+
+By default, loader will be rendered with the SvelteUI blue color. You can choose any color defined in the theme or extend your [own theme](theming/create-styles):
+
+<Preview code={loader}>
+    <Loader />
+</Preview>
+
+### Configure default loader
+
+You can configure default loader to be one of it's three variants, `circle`, `dots` and `bars`:
+
+<Preview code={variantLoaders}>
+    <SimpleGrid cols={3}>
+        <Loader variant="circle" />
+        <Loader variant="dots" />
+        <Loader variant="bars" />
+    </SimpleGrid>
+</Preview>
+
+### Size
+
+Size controls loader height or width (depends on loader variant). Loader has predefined sizes: `xs`, `sm`, `md`, `lg`, `xl`. Alternatively, you can use a number to set width or height in px:
+
+<Preview code={sizeLoaders}>
+    <Loader size="lg" />
+    <Loader size={50} />
+</Preview>

--- a/docs/src/pages/core/switch.md
+++ b/docs/src/pages/core/switch.md
@@ -10,6 +10,75 @@ source: 'svelte-core/src/lib/components/Switch/Switch.svelte'
 docs: 'core/switch.md'
 ---
 
-import { CodeBlock, Heading } from 'components'
+<script lang="ts">
+    import { SimpleGrid, Switch } from '@svelteuidev/core';
+    import { Heading, Preview } from 'components';
+
+    const switchCode = `
+        <script>
+            import { Switch } from '@svelteuidev/core';
+        <\/script>
+
+        <Switch label="I agree to sell my privacy" size="md" color="teal"\/>
+        <Switch onLabel="ON" offLabel="OFF" label="Setting 1" size="xl" color="pink"\/>
+        <Switch checked size="xs"\/>
+    `;
+    const labelSwitch = `
+        <script>
+            import { Switch } from '@svelteuidev/core';
+        <\/script>
+
+        <Switch size='sm' onLabel="ON" offLabel="OFF" \/>
+        <Switch size='md' onLabel="ON" offLabel="OFF" \/>
+        <Switch size='lg' onLabel="ON" offLabel="OFF" \/>
+        <Switch size='xl' onLabel="ON" offLabel="OFF" \/>
+    `;
+    const accessibilitySwitch = `
+        <script>
+            import { Switch } from '@svelteuidev/core';
+        <\/script>
+
+        <Switch \/> // -> not ok, input is not labeled
+        <Switch label="I agree to everything" \/> // -> ok, input and label is connected
+        <Switch aria-label="I agree to everything" \/> // -> ok, label is not visible but will be announced by screen reader
+    `;
+</script>
 
 <Heading />
+
+## Usage
+
+Switch component is used to enable/disable something, normally used for boolean values or for binary actions. The component dispatches an on change event, and supports a checked prop for programmatically setting the checked state.
+
+<Preview code={switchCode}>
+    <SimpleGrid cols={3}>
+        <Switch label="I agree to sell my privacy" size="md" color="teal"/>
+        <Switch onLabel="ON" offLabel="OFF" label="Setting 1" size="xl" color="pink"/>
+        <Switch checked size="xs"/>
+    </SimpleGrid>
+</Preview>
+
+### Inner labels and Size
+
+There is support for inserting text inside the switch for when it is enabled and/or disabled. It is also possible to control the size of the switch with predefined values: `xs`, `sm`, `md`, `lg`, `xl`.
+
+<Preview code={labelSwitch}>
+    <SimpleGrid cols={4}>
+        <Switch size='sm' onLabel="ON" offLabel="OFF" />
+        <Switch size='md' onLabel="ON" offLabel="OFF" />
+        <Switch size='lg' onLabel="ON" offLabel="OFF" />
+        <Switch size='xl' onLabel="ON" offLabel="OFF" />
+    </SimpleGrid>
+</Preview>
+
+## Accessibility
+
+Switch is a regular input with checkbox type. Provide `aria-label` if Switch is used without `label`:
+
+<Preview code={accessibilitySwitch}>
+    <SimpleGrid cols={3}>
+        <Switch />
+        <Switch label="I agree to everything" />
+        <Switch aria-label="I agree to everything" />
+    </SimpleGrid>
+</Preview>

--- a/docs/src/pages/core/text.md
+++ b/docs/src/pages/core/text.md
@@ -10,6 +10,184 @@ source: 'svelte-core/src/lib/components/Text/Text.svelte'
 docs: 'core/text.md'
 ---
 
-import { CodeBlock, Heading } from 'components'
+<script lang="ts">
+    import { Code, Text, Title } from '@svelteuidev/core';
+    import { Heading, Preview } from 'components';
+
+    const text = `
+        <script>
+            import { Text } from '@svelteuidev/core';
+        <\/script>
+
+        <Text size="xs">Extra small text<\/Text>
+        <Text size="sm">Small text<\/Text>
+        <Text size="md">Default text<\/Text>
+        <Text size="lg">Large text<\/Text>
+        <Text size="xl">Extra large text<\/Text>
+        <Text weight={'semibold'}>Semibold<\/Text>
+        <Text weight={'bold'}>Bold<\/Text>
+        <Text underline>Underlined<\/Text>
+        <Text variant="link" root="a" href="https://svelteui-docs.vercel.app">Link variant<\/Text>
+        <Text color="red">Red text<\/Text>
+        <Text color="blue">Blue text<\/Text>
+        <Text color="gray">Gray text<\/Text>
+        <Text transform="uppercase">Uppercase<\/Text>
+        <Text transform="capitalize">capitalized text<\/Text>
+        <Text align="center">Aligned to center<\/Text>
+        <Text align="right">Aligned to right<\/Text>
+    `;
+    const dimmedText = `
+        <script>
+            import { Text } from '@svelteuidev/core';
+        <\/script>
+
+        <Text color="dimmed">Dimmed text<\/Text>
+    `;
+    const gradientText = `
+        <script>
+            import { Text } from '@svelteuidev/core';
+        <\/script>
+
+        <Text
+            component="span"
+            align="center"
+            variant="gradient"
+            gradient={{ from: 'indigo', to: 'cyan', deg: 45 }}
+            size="xl"
+            weight={'bold'}
+        >
+            Indigo cyan gradient
+        <\/Text>
+    `;
+    const lineclampText = `
+        <script>
+            import { Text } from '@svelteuidev/core';
+        <\/script>
+
+        <Text lineClamp={4}>
+            From Bulbapedia: Bulbasaur is a small, quadrupedal Pokémon that has blue-green skin with darker patches. It has red eyes with white pupils, pointed, ear-like structures on top of its head, and a short, blunt snout with a wide mouth. A pair of small, pointed teeth are visible in the upper jaw when its mouth is open. Each of its thick legs ends with three sharp claws. On Bulbasaur's back is a green plant bulb, which is grown from a seed planted there at birth. The bulb also conceals two slender, tentacle-like vines.
+        <\/Text>
+    `;
+    const inheritText = `
+        <script>
+            import { Text, Title } from '@svelteuidev/core';
+        <\/script>
+
+        <Title order={3}>
+            Highlight{' '}
+            <Text color="blue" inherit component="span">
+                something
+            <\/Text>
+            in title
+        <\/Title>
+    `;
+    const customText = `
+        <script>
+            import { Code, Text } from '@svelteuidev/core';
+        <\/script>
+
+        <Text root="a">This is a anchor now<\/Text>
+        <Text root="p">This is a paragraph<\/Text>
+        <Text root={Code}>This is a Code Component<\/Text>
+    `;
+</script>
 
 <Heading />
+
+## Usage
+
+Use Text component to display text and links with theme styles. Control Text styles with props:
+
+* **size** - font-size from `theme.fontSizes` - `xs`, `sm`, `md`, `lg`, `xl`
+* **color** - color from `theme.colors` - red, green, blue, etc.
+* **weight** - font-weight property - `thin`, `extralight`, `light`, `normal`, `medium`, `semibold`, `bold`, `extrabold` or a number.
+* **underline** - underline text
+* **transform** - text-transform property - uppercase, lowercase, capitalize
+* **align** - text-align property
+* **variant** - text or link predefined styles
+* **inline** - sets the line-height to 1
+
+<Preview code={text}>
+    <Text size="xs">Extra small text</Text>
+    <Text size="sm">Small text</Text>
+    <Text size="md">Default text</Text>
+    <Text size="lg">Large text</Text>
+    <Text size="xl">Extra large text</Text>
+    <Text weight={'semibold'}>Semibold</Text>
+    <Text weight={'bold'}>Bold</Text>
+    <Text underline>Underlined</Text>
+    <Text variant="link" root="a" href="https://svelteui-docs.vercel.app">Link variant</Text>
+    <Text color="red">Red text</Text>
+    <Text color="blue">Blue text</Text>
+    <Text color="gray">Gray text</Text>
+    <Text transform="uppercase">Uppercase</Text>
+    <Text transform="capitalize">capitalized text</Text>
+    <Text align="center">Aligned to center</Text>
+    <Text align="right">Aligned to right</Text>
+</Preview>
+
+### Dimmed
+
+Text supports special `dimmed` value in color prop. It sets color to `theme.colors.dark200` in dark theme and to `theme.colors.gray600` in light:
+
+<Preview code={dimmedText}>
+    <Text color="dimmed">Dimmed text</Text>
+</Preview>
+
+### Gradient variant
+
+To use gradient as Text color:
+
+* set `variant` to `gradient`
+* set `gradient` to `(from: 'color-from', to: 'color-to', deg: 135 )`, where
+    * `color-from` and `color-to` are color from `theme.colors`
+    * `deg` is linear gradient degree
+
+<Preview code={gradientText}>
+    <Text
+        component="span"
+        align="center"
+        variant="gradient"
+        gradient={{ from: 'indigo', to: 'cyan', deg: 45 }}
+        size="xl"
+        weight={'bold'}
+    >
+        Indigo cyan gradient
+    </Text>
+</Preview>
+
+### Line Clamp
+
+Specify maximum amount of lines with `lineClamp` prop. This option uses [-webkit-line-clamp](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp) CSS property ([caniuse](https://caniuse.com/css-line-clamp)). Note that padding-bottom cannot be set on text element:
+
+<Preview code={lineclampText}>
+    <div style="width: 400px; margin: 10px 0px 10px 0px;">
+        <Text lineClamp={4}>
+            From Bulbapedia: Bulbasaur is a small, quadrupedal Pokémon that has blue-green skin with darker patches. It has red eyes with white pupils, pointed, ear-like structures on top of its head, and a short, blunt snout with a wide mouth. A pair of small, pointed teeth are visible in the upper jaw when its mouth is open. Each of its thick legs ends with three sharp claws. On Bulbasaur's back is a green plant bulb, which is grown from a seed planted there at birth. The bulb also conceals two slender, tentacle-like vines.
+        </Text>
+    </div>
+</Preview>
+
+### Inherit Styles
+
+Text always applies font-size, font-family and line-height styles, but in some cases this is not a desired behavior. To force Text to inherit parent styles set `inherit` prop. For example, highlight part of [Title](core/title):
+
+<Preview code={inheritText}>
+    <Title order={3}>
+        Highlight{' '}
+        <Text color="blue" inherit component="span">
+            something
+        </Text>
+        in title
+    </Title>
+</Preview>
+
+### Custom component
+
+By default, text is rendered as div element, to change it by set `root` prop:
+
+<Preview code={customText}>
+    <Text root="a">This is a anchor now</Text>
+    <Text root="p">This is a paragraph</Text>
+    <Text root={Code}>This is a Code Component</Text>
+</Preview>

--- a/docs/src/pages/core/title.md
+++ b/docs/src/pages/core/title.md
@@ -10,6 +10,54 @@ source: 'svelte-core/src/lib/components/Title/Title.svelte'
 docs: 'core/title.md'
 ---
 
-import { CodeBlock, Heading } from 'components'
+<script lang="ts">
+    import { Title } from '@svelteuidev/core';
+    import { Heading, Preview } from 'components';
+
+    const title = `
+        <script>
+            import { Title } from '@svelteuidev/core';
+        <\/script>
+
+        <Title order={1}>This is h1 title<\/Title>
+        <Title order={2}>This is h2 title<\/Title>
+        <Title order={3}>This is h3 title<\/Title>
+        <Title order={4}>This is h4 title<\/Title>
+        <Title order={5}>This is h5 title<\/Title>
+        <Title order={6}>This is h6 title<\/Title>
+    `;
+    const sharedTitle = `
+        <script>
+            import { Title } from '@svelteuidev/core';
+        <\/script>
+
+        <Title order={1}>This is h1 title<\/Title>
+        <Title order={1} variant='gradient'>This is h1 title with a twist<\/Title>
+    `;
+</script>
 
 <Heading />
+
+## Usage
+
+Use the Title component to render h1-h6 headings with SvelteUI theme styles. By default, Title has no margins and paddings.
+
+Pass `order` prop to render specific element (h1-h6), default order is 1:
+
+<Preview code={title}>
+    <Title order={1}>This is h1 title</Title>
+    <Title order={2}>This is h2 title</Title>
+    <Title order={3}>This is h3 title</Title>
+    <Title order={4}>This is h4 title</Title>
+    <Title order={5}>This is h5 title</Title>
+    <Title order={6}>This is h6 title</Title>
+</Preview>
+
+### Shared Props
+
+The Title component takes all the same props as the Text component
+
+<Preview code={sharedTitle}>
+    <Title order={1}>This is h1 title</Title>
+    <Title order={1} variant='gradient'>This is h1 title with a twist</Title>
+</Preview>


### PR DESCRIPTION
Ported from the old docs the components:
* Button
* Code
* Loader
* ActionIcon + CloseButton
* Image + BackgroundImage
* Switch
* Text
* Title

Example of the button docs:

![image](https://user-images.githubusercontent.com/25725586/167732477-1b4aadfc-4b96-4e20-983a-ac5aa40fef6b.png)

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `npm run lint` or just run `npm run repo:prepush` and check to see if it's passing.
