### PR TITLE
[docs]: port actions and utilities documentation

### DIFF
--- a/docs/src/pages/actions/use-click-outside.md
+++ b/docs/src/pages/actions/use-click-outside.md
@@ -9,6 +9,73 @@ docs: 'actions/use-click-outside.md'
 source: 'svelteui-actions/src/lib/dist/use-click-outside/use-click-outside.ts'
 ---
 
-import { CodeBlock, Heading } from 'components'
+<script lang='ts'>
+    import { Button } from '@svelteuidev/core';
+	import { clickoutside } from '@svelteuidev/actions';
+    import { Heading, Preview } from 'components'
+
+	let open = true;
+
+    const code = `
+    <script>
+        import { Button } from '@svelteuidev/core';
+        import { clickoutside } from '@svelteuidev/actions';
+
+        let open = true;
+    <\/script>
+
+    <div use:clickoutside={{ enabled: open, callback: () => open = false }}>
+        <Button on:click={() => open = true}>Open Modal<\/Button>
+        {#if open}
+            <div style="border: 2px solid gray; padding: 2rem;">
+                This is a modal, click anywhere to close
+            <\/div>
+        {:else if !open}
+            <div>
+                There is no modal
+            <\/div>
+        {\/if}
+    <\/div>
+    `
+</script>
 
 <Heading />
+
+## Usage
+
+With the `use-click-outside` action, a callback function will be fired whenever the user clicks outside of the dom node the action is applied to.
+
+<Preview {code}>
+    <div use:clickoutside={{ enabled: open, callback: () => open = false }}>
+        <Button on:click={() => open = true}>Open Modal</Button>
+        {#if open}
+            <div style="border: 2px solid gray; padding: 2rem;">
+                This is a modal, click anywhere to close
+            </div>
+        {:else if !open}
+            <div>
+                There is no modal
+            </div>
+        {/if}
+    </div>
+</Preview>
+
+## Params
+
+| Param    | Description                                                                    |
+| -------- | ------------------------------------------------------------------------------ |
+| enabled  | Sets the action to an enabled state if true, if false, action will not trigger |
+| callback | The callback to be fired once the user clicks outside of the DOM node          |
+
+## Events
+
+The `use-click-outside` action does not dispatch any custom events.
+
+## Definition
+
+```ts
+export function clickOutside(
+    node: HTMLElement,
+    params: { enabled: boolean; callback?: (node?: HTMLElement) => void }
+): ReturnType<Action>;
+```

--- a/docs/src/pages/actions/use-clipboard.md
+++ b/docs/src/pages/actions/use-clipboard.md
@@ -3,7 +3,7 @@ title: 'use-clipboard'
 group: 'svelteuidev-actions'
 packageGroup: '@svelteuidev/actions'
 slug: /actions/use-clipboard/
-description: 'Copies text to the clipboard when dom element is clicked'
+description: 'Copies text to the clipboard when DOM element is clicked'
 import: "import { clipboard } from '@svelteuidev/actions';"
 docs: 'actions/use-clipboard.md'
 source: 'svelteui-actions/src/lib/dist/use-clipboard/use-clipboard.ts'
@@ -12,7 +12,7 @@ source: 'svelteui-actions/src/lib/dist/use-clipboard/use-clipboard.ts'
 <script lang='ts'>
     import { Button } from '@svelteuidev/core';
 	import { clipboard } from '@svelteuidev/actions';
-    import { CodeBlock, Heading, Preview } from 'components'
+    import { Heading, Preview } from 'components'
 
 	let textToCopy = 'This message was copied';
 	let copied = false;
@@ -49,6 +49,8 @@ source: 'svelteui-actions/src/lib/dist/use-clipboard/use-clipboard.ts'
 
 ## Usage
 
+With the use-clipboard action, text passed into the text param will be copied to the users clipboard.
+
 <Preview {code}>
 <Button
 use={[[clipboard, textToCopy]]}
@@ -57,8 +59,6 @@ color={copied ? 'green' : 'blue'} >
 {copied ? 'copied' : 'Click me to copy text'}
 </Button>
 </Preview>
-
-With the use-clipboard action, text passed into the text param will be copied to the users clipboard.
 
 ## Params
 

--- a/docs/src/pages/actions/use-css-variable.md
+++ b/docs/src/pages/actions/use-css-variable.md
@@ -9,6 +9,74 @@ docs: 'actions/use-css-variable.md'
 source: 'svelteui-actions/src/lib/dist/use-css-variable/use-css-variable.ts'
 ---
 
-import { CodeBlock, Heading } from 'components'
+<script lang='ts'>
+    import { Button } from '@svelteuidev/core';
+	import { cssvariable } from '@svelteuidev/actions';
+    import { Heading, Preview } from 'components'
+
+	let isRed = true;
+
+    const code = `
+    <script>
+        import { Button } from '@svelteuidev/core';
+        import { cssvariable } from '@svelteuidev/actions';
+
+        let isRed = true;
+
+        $: styleVars = {
+            titleColor: isRed ? 'red' : 'blue'
+        };
+    <\/script>
+
+    <div use:cssvariable={styleVars}>
+        <!-- anything here will have access to var(--titleColor) -->
+        <p>This text is normal<\/p>
+        <p class="example">This text is using the variable<\/p>
+    <\/div>
+    <Button on:click={() => (isRed = !isRed)}>Click to switch colors<\/Button>
+
+    <style>
+        .example-text {
+            color: var(--titleColor);
+        }
+    <\/style>
+    `;
+
+    $: styleVars = { titleColor: isRed ? 'red' : 'blue' };
+</script>
 
 <Heading />
+
+## Usage
+
+With the `use-css-variable` action, an object of properties will be treated as css custom variables. By defining this object inside of a `$: ` reactive block, `use-css-variable` can update those css properties on the fly whenever some of its values change.
+
+<Preview {code}>
+    <div use:cssvariable={styleVars}>
+        <p>This text is normal</p>
+        <p class="example-text">This text is using the variable</p>
+    </div>
+    <Button on:click={() => (isRed = !isRed)}>Click to switch colors</Button>
+</Preview>
+
+<style>
+    .example-text {
+        color: var(--titleColor);
+    }
+</style>
+
+## Params
+
+| Param | Description                                                          |
+| ----- | -------------------------------------------------------------------- |
+| props | The object that possesses the variables, and their associated values |
+
+## Events
+
+The `use-css-variable` action does not dispatch any custom events.
+
+## Definition
+
+```ts
+export function cssvariable(node: HTMLElement, props: UnknownKeyString<string>): ReturnType<Action>;
+```

--- a/docs/src/pages/actions/use-download.md
+++ b/docs/src/pages/actions/use-download.md
@@ -9,6 +9,66 @@ docs: 'actions/use-download.md'
 source: 'svelteui-actions/src/lib/dist/use-download/use-download.ts'
 ---
 
-import { CodeBlock, Heading } from 'components'
+<script lang='ts'>
+    import { Button } from '@svelteuidev/core';
+	import { download } from '@svelteuidev/actions';
+    import { Heading, Preview } from 'components'
+
+    const code = `
+    <script>
+        import { Button } from '@svelteuidev/core';
+        import { download } from '@svelteuidev/actions';
+    <\/script>
+
+    <div
+        use:download={{ blob: new Blob([]), filename: "test.txt" }}
+        on:usedownload={() => console.log('File Downloaded')}
+    >
+        <Button variant='outline'>
+            Download File
+        <\/Button>
+    <\/div>
+    `;
+</script>
 
 <Heading />
+
+## Usage
+
+With the `use-download` action, a download will occur with a given Blob object as a file with the given filename.
+
+<Preview {code}>
+    <div
+        use:download={{ blob: new Blob([]), filename: "test.txt" }}
+        on:usedownload={() => console.log('File Downloaded')}
+    >
+        <Button variant='outline'>
+            Download File
+        </Button>
+    </div>
+</Preview>
+
+## Params
+
+| Param    | Description                                      |
+| -------- | ------------------------------------------------ |
+| blob     | The Blob object representing immutable, raw data |
+| filename | The name of the file to be downloaded            |
+
+## Events
+
+The `use-download` action dispatches custom events. Each custom event takes a callback function just like other events *e.g.* `on:click=`
+
+```ts
+on:usedownload?: (callback: (any) => unknown) => void;
+on:usedownload-error?: (callback: (any) => unknown) => void;
+```
+
+## Definition
+
+```ts
+export function download(
+    node: HTMLElement,
+    params: { blob: Blob; filename: string }
+): ReturnType<Action>;
+```

--- a/docs/src/pages/actions/use-focus.md
+++ b/docs/src/pages/actions/use-focus.md
@@ -3,12 +3,74 @@ title: 'use-focus'
 group: 'svelteuidev-actions'
 packageGroup: '@svelteuidev/actions'
 slug: /actions/use-focus/
-description: 'Calls focus on a node once mounted into the dom'
+description: 'Calls focus on a node once mounted into the DOM'
 import: "import { focus } from '@svelteuidev/actions';"
 docs: 'actions/use-focus.md'
 source: 'svelteui-actions/src/lib/dist/use-focus/use-focus.ts'
 ---
 
-import { CodeBlock, Heading } from 'components'
+<script lang='ts'>
+    import { Button } from '@svelteuidev/core';
+	import { focus } from '@svelteuidev/actions';
+    import { Heading, Preview } from 'components'
+
+	let name = 'world';
+    let editing = false;
+    function toggleEdit() {
+        editing = !editing;
+    }
+
+    const code = `
+    <script>
+        import { Button } from '@svelteuidev/core';
+        import { focus } from '@svelteuidev/actions';
+
+        let name = 'world';
+        let editing = false;
+        function toggleEdit() {
+            editing = !editing;
+        }
+    <\/script>
+
+    <p>Name: {name}<\/p>
+    {#if editing}
+        <label>
+            Name
+            <input use:focus type="text" bind:value={name} \/>
+        <\/label>
+    {\/if}
+    <Button on:click={toggleEdit}>{editing ? 'Confirm' : 'Edit'}<\/Button>
+    `
+</script>
 
 <Heading />
+
+## Usage
+
+With the `use-focus` action, the affected DOM node gets focused when it is mounted into the DOM. Only "focusable" elements should use this action. Type errors will appear if this is not the case.
+
+<Preview {code}>
+    <p>Name: {name}</p>
+    {#if editing}
+        <label>
+            Name
+            <input use:focus type="text" bind:value={name} />
+        </label>
+    {/if}
+    <Button on:click={toggleEdit}>{editing ? 'Confirm' : 'Edit'}</Button>
+</Preview>
+
+
+## Params
+
+This `use-focus` action does not take any params.
+
+## Events
+
+The use-focus action does not dispatch any custom events.
+
+## Definition
+
+```ts
+export function focus(node: FocusableElement): ReturnType<Action>;
+```

--- a/docs/src/pages/actions/use-page-leave.md
+++ b/docs/src/pages/actions/use-page-leave.md
@@ -9,6 +9,45 @@ docs: 'actions/use-page-leave.md'
 source: 'svelteui-actions/src/lib/dist/use-page-leave/use-page-leave.ts'
 ---
 
-import { CodeBlock, Heading } from 'components'
+<script lang='ts'>
+	import { pageleave } from '@svelteuidev/actions';
+    import { Heading, Preview } from 'components'
+
+    const code = `
+    <script>
+        import { pageleave } from '@svelteuidev/actions';
+
+        $: count = 0;
+    <\/script>
+
+    <div use:pageleave={() => count++}>Switch the page to see the counter go up: {count}<\/div>
+    `;
+
+    $: count = 0;
+</script>
 
 <Heading />
+
+## Usage
+
+The `use-page-leave` action calls given function when mouse leaves the page.
+
+<Preview {code}>
+    <div use:pageleave={() => count++}>Switch the page to see the counter go up: {count}</div>
+</Preview>
+
+## Params
+
+| Param    | Description                                    |
+| -------- | ---------------------------------------------- |
+| callback | The callback to be fired when the page is left |
+
+## Events
+
+The `use-page-leave` action does not dispatch any custom events.
+
+## Definition
+
+```ts
+export function pageleave(node: HTMLElement, callback: Fn<void>): ReturnType<Action>;
+```

--- a/docs/src/pages/actions/use-tab-leave.md
+++ b/docs/src/pages/actions/use-tab-leave.md
@@ -9,6 +9,45 @@ docs: 'actions/use-tab-leave.md'
 source: 'svelteui-actions/src/lib/dist/use-tab-leave/use-tab-leave.ts'
 ---
 
-import { CodeBlock, Heading } from 'components'
+<script lang='ts'>
+	import { tableave } from '@svelteuidev/actions';
+    import { Heading, Preview } from 'components'
+
+    const code = `
+    <script>
+        import { tableave } from '@svelteuidev/actions';
+
+        $: count = 0;
+    <\/script>
+
+    <div use:tableave={() => count++}>Switch the tab to see the counter go up: {count}<\/div>
+    `;
+
+    $: count = 0;
+</script>
 
 <Heading />
+
+## Usage
+
+The `use-tab-leave` action calls given function when the current tab is switched.
+
+<Preview {code}>
+    <div use:tableave={() => count++}>Switch the tab to see the counter go up: {count}</div>
+</Preview>
+
+## Params
+
+| Param    | Description                                       |
+| -------- | ------------------------------------------------- |
+| callback | The callback to be fired when the tab is switched |
+
+## Events
+
+The `use-tab-leave` action does not dispatch any custom events.
+
+## Definition
+
+```ts
+export function tableave(node: HTMLElement, callback: Fn<void>): ReturnType<Action>;
+```

--- a/docs/src/pages/core/action-icon.md
+++ b/docs/src/pages/core/action-icon.md
@@ -16,67 +16,67 @@ docs: 'core/action-icon.md'
     import { Heading, Preview } from 'components';
 
     const action = `
-        <script>
-            import { ActionIcon } from '@svelteuidev/core';
-            import { GithubLogo } from "radix-icons-svelte";
-        <\/script>
+    <script>
+        import { ActionIcon } from '@svelteuidev/core';
+        import { GithubLogo } from "radix-icons-svelte";
+    <\/script>
 
-        <ActionIcon><GithubLogo size={16} \/><\/ActionIcon>
+    <ActionIcon><GithubLogo size={16} \/><\/ActionIcon>
     `;
     const variantActions = `
-        <script>
-            import { ActionIcon } from '@svelteuidev/core';
-            import { GithubLogo } from "radix-icons-svelte";
-        <\/script>
+    <script>
+        import { ActionIcon } from '@svelteuidev/core';
+        import { GithubLogo } from "radix-icons-svelte";
+    <\/script>
 
-        <ActionIcon color="blue" variant="hover"><GithubLogo size={16} \/><\/ActionIcon>
-        <ActionIcon color="blue" variant="default"><GithubLogo size={16} \/><\/ActionIcon>
-        <ActionIcon color="blue" variant="transparent"><GithubLogo size={16} \/><\/ActionIcon>
-        <ActionIcon color="blue" variant="filled"><GithubLogo size={16} \/><\/ActionIcon>
-        <ActionIcon color="blue" variant="light"><GithubLogo size={16} \/><\/ActionIcon>
-        <ActionIcon color="blue" variant="outline"><GithubLogo size={16} \/><\/ActionIcon>
+    <ActionIcon color="blue" variant="hover"><GithubLogo size={16} \/><\/ActionIcon>
+    <ActionIcon color="blue" variant="default"><GithubLogo size={16} \/><\/ActionIcon>
+    <ActionIcon color="blue" variant="transparent"><GithubLogo size={16} \/><\/ActionIcon>
+    <ActionIcon color="blue" variant="filled"><GithubLogo size={16} \/><\/ActionIcon>
+    <ActionIcon color="blue" variant="light"><GithubLogo size={16} \/><\/ActionIcon>
+    <ActionIcon color="blue" variant="outline"><GithubLogo size={16} \/><\/ActionIcon>
     `;
     const colorActions = `
-        <script>
-            import { ActionIcon } from '@svelteuidev/core';
-            import { GithubLogo } from "radix-icons-svelte";
-        <\/script>
+    <script>
+        import { ActionIcon } from '@svelteuidev/core';
+        import { GithubLogo } from "radix-icons-svelte";
+    <\/script>
 
-        <ActionIcon color="red"><GithubLogo size={16} \/><\/ActionIcon>
-        <ActionIcon color="green"><GithubLogo size={16} \/><\/ActionIcon>
-        <ActionIcon color="teal"><GithubLogo size={16} \/><\/ActionIcon>
-        <ActionIcon color="gray"><GithubLogo size={16} \/><\/ActionIcon>
-        <ActionIcon color="blue"><GithubLogo size={16} \/><\/ActionIcon>
-        <ActionIcon color="yellow"><GithubLogo size={16} \/><\/ActionIcon>
+    <ActionIcon color="red"><GithubLogo size={16} \/><\/ActionIcon>
+    <ActionIcon color="green"><GithubLogo size={16} \/><\/ActionIcon>
+    <ActionIcon color="teal"><GithubLogo size={16} \/><\/ActionIcon>
+    <ActionIcon color="gray"><GithubLogo size={16} \/><\/ActionIcon>
+    <ActionIcon color="blue"><GithubLogo size={16} \/><\/ActionIcon>
+    <ActionIcon color="yellow"><GithubLogo size={16} \/><\/ActionIcon>
     `;
     const sizeActions = `
-        <script>
-            import { ActionIcon } from '@svelteuidev/core';
-            import { GithubLogo } from "radix-icons-svelte";
-        <\/script>
+    <script>
+        import { ActionIcon } from '@svelteuidev/core';
+        import { GithubLogo } from "radix-icons-svelte";
+    <\/script>
 
-        <ActionIcon radius="lg" color="blue" variant="filled"><GithubLogo size={16} \/><\/ActionIcon> // -> theme predefined large radius
-        <ActionIcon radius={10} color="blue" variant="filled"><GithubLogo size={16} \/><\/ActionIcon> // -> { borderRadius: '10px' }
-        <ActionIcon size="sm" color="blue" variant="filled"><GithubLogo size={16} \/><\/ActionIcon> // -> predefined small size
-        <ActionIcon size={50} color="blue" variant="filled"><GithubLogo size={16} \/><\/ActionIcon> // -> { width: '50px', height: '50px' }
+    <ActionIcon radius="lg" color="blue" variant="filled"><GithubLogo size={16} \/><\/ActionIcon> // -> theme predefined large radius
+    <ActionIcon radius={10} color="blue" variant="filled"><GithubLogo size={16} \/><\/ActionIcon> // -> { borderRadius: '10px' }
+    <ActionIcon size="sm" color="blue" variant="filled"><GithubLogo size={16} \/><\/ActionIcon> // -> predefined small size
+    <ActionIcon size={50} color="blue" variant="filled"><GithubLogo size={16} \/><\/ActionIcon> // -> { width: '50px', height: '50px' }
     `;
     const closeButton = `
-        <script>
-            import { closeButton } from '@svelteuidev/core';
-        <\/script>
+    <script>
+        import { closeButton } from '@svelteuidev/core';
+    <\/script>
 
-        <CloseButton variant="filled" \/>
-        <CloseButton size="xl" iconSize={20} variant="filled" \/>
+    <CloseButton variant="filled" \/>
+    <CloseButton size="xl" iconSize={20} variant="filled" \/>
     `;
     const accessibility = `
-        <script>
-            import { ActionIcon } from '@svelteuidev/core';
-            import { GithubLogo } from "radix-icons-svelte";
-        <\/script>
+    <script>
+        import { ActionIcon } from '@svelteuidev/core';
+        import { GithubLogo } from "radix-icons-svelte";
+    <\/script>
 
-        <ActionIcon><GithubLogo size={16} \/><\/ActionIcon> // -> not visible to screen reader
-        <ActionIcon title="Settings"><GithubLogo size={16} \/><\/ActionIcon> // -> ok
-        <ActionIcon aria-label="Settings"><GithubLogo size={16} \/><\/ActionIcon> // -> ok
+    <ActionIcon><GithubLogo size={16} \/><\/ActionIcon> // -> not visible to screen reader
+    <ActionIcon title="Settings"><GithubLogo size={16} \/><\/ActionIcon> // -> ok
+    <ActionIcon aria-label="Settings"><GithubLogo size={16} \/><\/ActionIcon> // -> ok
     `;
 </script>
 

--- a/docs/src/pages/core/button.md
+++ b/docs/src/pages/core/button.md
@@ -16,92 +16,92 @@ docs: 'core/button.md'
     import { Heading, Preview } from 'components'
 
     const simpleButtons = `
-        <script>
-            import { Button } from '@svelteuidev/core';
-        <\/script>
+    <script>
+        import { Button } from '@svelteuidev/core';
+    <\/script>
 
-        <Button \/>
-        <Button>Click me!<\/Button>
+    <Button \/>
+    <Button>Click me!<\/Button>
     `;
     const variantButtons = `
-        <script>
-            import { Button } from '@svelteuidev/core';
-        <\/script>
+    <script>
+        import { Button } from '@svelteuidev/core';
+    <\/script>
 
-        <Button color="red" \/>
-        <Button variant="outline"\/>
-        <Button variant="filled"\/>
+    <Button color="red" \/>
+    <Button variant="outline"\/>
+    <Button variant="filled"\/>
     `;
     const gradientButtons = `
-        <script>
-            import { Button } from '@svelteuidev/core';
-        <\/script>
+    <script>
+        import { Button } from '@svelteuidev/core';
+    <\/script>
 
-        <Button variant='gradient'>Default<\/Button>
-        <Button variant='gradient' gradient={{from: 'teal', to: 'green', deg: 105}}>Lime Green<\/Button>
-        <Button variant='gradient' gradient={{from: 'teal', to: 'blue', deg: 60}}>Teal Blue<\/Button>
-        <Button variant='gradient' gradient={{from: 'orange', to: 'red', deg: 45}}>Orange red<\/Button>
-        <Button variant='gradient' gradient={{from: 'grape', to: 'pink', deg: 35}}>Grape Pink<\/Button>
+    <Button variant='gradient'>Default<\/Button>
+    <Button variant='gradient' gradient={{from: 'teal', to: 'green', deg: 105}}>Lime Green<\/Button>
+    <Button variant='gradient' gradient={{from: 'teal', to: 'blue', deg: 60}}>Teal Blue<\/Button>
+    <Button variant='gradient' gradient={{from: 'orange', to: 'red', deg: 45}}>Orange red<\/Button>
+    <Button variant='gradient' gradient={{from: 'grape', to: 'pink', deg: 35}}>Grape Pink<\/Button>
     `;
     const whiteButtons = `
-        <script>
-            import { Button } from '@svelteuidev/core';
-        <\/script>
+    <script>
+        import { Button } from '@svelteuidev/core';
+    <\/script>
 
-        <Button variant="white">Click Me<\/Button>
-        <Button variant="white" color="red">I am red<\/Button>
+    <Button variant="white">Click Me<\/Button>
+    <Button variant="white" color="red">I am red<\/Button>
     `;
     const loadingButtons = `
-        <script>
-            import { Button } from '@svelteuidev/core';
-        <\/script>
+    <script>
+        import { Button } from '@svelteuidev/core';
+    <\/script>
 
-        <Button loading={true}>I am loading<\/Button>
-        <Button loading={true} loaderPosition={"right"}>I am loading on the right<\/Button>
+    <Button loading={true}>I am loading<\/Button>
+    <Button loading={true} loaderPosition={"right"}>I am loading on the right<\/Button>
     `;
     const customizeButtons = `
-        <script>
-            import { Button } from '@svelteuidev/core';
-            import { GithubLogo } from "radix-icons-svelte";
-        <\/script>
+    <script>
+        import { Button } from '@svelteuidev/core';
+        import { GithubLogo } from "radix-icons-svelte";
+    <\/script>
 
-        <Button override={{ backgroundColor: 'red' }} variant='outline'>Click Me<\/Button>
-        <Button>
-            <GithubLogo size={16} \/> I love open source!
-        <\/Button>
+    <Button override={{ backgroundColor: 'red' }} variant='outline'>Click Me<\/Button>
+    <Button>
+        <GithubLogo size={16} \/> I love open source!
+    <\/Button>
     `;
     const sizeButtons = `
-        <script>
-            import { Button } from '@svelteuidev/core';
-        <\/script>
+    <script>
+        import { Button } from '@svelteuidev/core';
+    <\/script>
 
-        <Button radius="lg" \/> // -> theme predefined large radius
-        <Button radius={10} \/> // -> ( borderRadius: '10px' )
-        <Button size="sm" \/> // -> predefined small size
-        <Button size="lg" \/> // -> predefined large size
+    <Button radius="lg" \/> // -> theme predefined large radius
+    <Button radius={10} \/> // -> ( borderRadius: '10px' )
+    <Button size="sm" \/> // -> predefined small size
+    <Button size="lg" \/> // -> predefined large size
     `;
     const compactButtons = `
-        <script>
-            import { Button } from '@svelteuidev/core';
-        <\/script>
+    <script>
+        import { Button } from '@svelteuidev/core';
+    <\/script>
 
-        <Button compact>Click Me<\/Button>
-        <Button variant='outline' compact>Click Me<\/Button>
-        <Button variant='default' compact>Click Me<\/Button>
+    <Button compact>Click Me<\/Button>
+    <Button variant='outline' compact>Click Me<\/Button>
+    <Button variant='default' compact>Click Me<\/Button>
     `;
     const fullsizeButtons = `
-        <script>
-            import { Button } from '@svelteuidev/core';
-        <\/script>
+    <script>
+        import { Button } from '@svelteuidev/core';
+    <\/script>
 
-        <Button fullSize>Click Me<\/Button>
+    <Button fullSize>Click Me<\/Button>
     `;
     const rootButtons = `
-        <script>
-            import { Button } from '@svelteuidev/core';
-        <\/script>
+    <script>
+        import { Button } from '@svelteuidev/core';
+    <\/script>
 
-        <Button href="https://github.com/svelteuidev/svelteui">I go to svelteuidev/svelteui<\/Button>
+    <Button href="https://github.com/svelteuidev/svelteui">I go to svelteuidev/svelteui<\/Button>
     `;
 </script>
 

--- a/docs/src/pages/core/code.md
+++ b/docs/src/pages/core/code.md
@@ -15,27 +15,27 @@ docs: 'core/code.md'
     import { Heading, Preview } from 'components';
 
     const code = `
-        <script>
-            import { Code } from '@svelteuidev/core';
-        <\/script>
+    <script>
+        import { Code } from '@svelteuidev/core';
+    <\/script>
 
-        <Code>This code will be inline<\/Code>
+    <Code>This code will be inline<\/Code>
     `;
     const blockCode = `
-        <script>
-            import { Code } from '@svelteuidev/core';
-        <\/script>
+    <script>
+        import { Code } from '@svelteuidev/core';
+    <\/script>
 
-        <Code block copy>This code will be in block and you can copy<\/Code>
+    <Code block copy>This code will be in block and you can copy<\/Code>
     `;
     const colorCode = `
-        <script>
-            import { Code } from '@svelteuidev/core';
-        <\/script>
+    <script>
+        import { Code } from '@svelteuidev/core';
+    <\/script>
 
-        <Code color="red">This code is red<\/Code>
-        <Code color="teal">This code is teal<\/Code>
-        <Code color="blue">This code is blue<\/Code>
+    <Code color="red">This code is red<\/Code>
+    <Code color="teal">This code is teal<\/Code>
+    <Code color="blue">This code is blue<\/Code>
     `;
 </script>
 

--- a/docs/src/pages/core/image.md
+++ b/docs/src/pages/core/image.md
@@ -18,91 +18,91 @@ docs: 'core/image.md'
     const doggo = "https://images.unsplash.com/photo-1627552245715-77d79bbf6fe2?auto=format&fit=crop&w=640&q=80";
 
     const image = `
-        <script>
-            import { Image } from '@svelteuidev/core';
-        <\/script>
+    <script>
+        import { Image } from '@svelteuidev/core';
+    <\/script>
 
-        <Image
-            radius="md"
-            src={url}
-            alt="Random unsplash image"
-        \/>
+    <Image
+        radius="md"
+        src={url}
+        alt="Random unsplash image"
+    \/>
     `;
     const sizeImage = `
-        <script>
-            import { Image } from '@svelteuidev/core';
-        <\/script>
+    <script>
+        import { Image } from '@svelteuidev/core';
+    <\/script>
 
-        <Image
-            width={200}
-            height={80}
-            src={url}
-        \/>
-        <Image
-            width={200}
-            height={80}
-            fit="contain"
-            src={url}
-        \/>
-        <Image
-            height={80}
-            src={url}
-        \/>
+    <Image
+        width={200}
+        height={80}
+        src={url}
+    \/>
+    <Image
+        width={200}
+        height={80}
+        fit="contain"
+        src={url}
+    \/>
+    <Image
+        height={80}
+        src={url}
+    \/>
     `;
     const placeholderImage = `
-        <script>
-            import { Image } from '@svelteuidev/core';
-        <\/script>
+    <script>
+        import { Image } from '@svelteuidev/core';
+    <\/script>
 
-        <Image
-            width={200}
-            height={120}
-            src={null}
-            alt="Without placeholder"
-        \/>
-        <Image
-            width={200}
-            height={120}
-            src={null}
-            alt="With default placeholder"
-            usePlaceholder
-        \/>
+    <Image
+        width={200}
+        height={120}
+        src={null}
+        alt="Without placeholder"
+    \/>
+    <Image
+        width={200}
+        height={120}
+        src={null}
+        alt="With default placeholder"
+        usePlaceholder
+    \/>
     `;
     const captionImage = `
-        <script>
-            import { Image } from '@svelteuidev/core';
-        <\/script>
+    <script>
+        import { Image } from '@svelteuidev/core';
+    <\/script>
 
-        <Image
-            radius="md"
-            src={doggo}
-            alt="Random unsplash image"
-            caption="My dog begging for treats"
-        \/>
+    <Image
+        radius="md"
+        src={doggo}
+        alt="Random unsplash image"
+        caption="My dog begging for treats"
+    \/>
     `;
     const radiusImage = `
-        <script>
-            import { Image } from '@svelteuidev/core';
-        <\/script>
+    <script>
+        import { Image } from '@svelteuidev/core';
+    <\/script>
 
-        <Image radius={0} src={doggo} \/>
-        <Image radius={"lg"} src={doggo} \/>
-        <Image radius={10} src={doggo} \/>
+    <Image radius={0} src={doggo} \/>
+    <Image radius={"lg"} src={doggo} \/>
+    <Image radius={10} src={doggo} \/>
     `;
     const backgroundImage = `
-        <script>
-            import { BackgroundImage, Text } from '@svelteuidev/core';
-        <\/script>
+    <script>
+        import { BackgroundImage, Text } from '@svelteuidev/core';
+    <\/script>
 
-        <BackgroundImage
-            src={url}
-            radius="sm"
-        >
-            <Text color="#fff">
-                BackgroundImage component can be used to add any content on image. It is useful for hero
-                headers and other similar sections
-            <\/Text>
-        <\/BackgroundImage>
+    <BackgroundImage
+        src={url}
+        radius="sm"
+    >
+        <Text color="#fff">
+            BackgroundImage component can be used to add any content on image. It is useful for hero
+            headers and other similar sections
+        <\/Text>
+    <\/BackgroundImage>
     `;
 </script>
 

--- a/docs/src/pages/core/loader.md
+++ b/docs/src/pages/core/loader.md
@@ -15,28 +15,28 @@ docs: 'core/loader.md'
     import { Heading, Preview } from 'components';
 
     const loader = `
-        <script>
-            import { Loader } from '@svelteuidev/core';
-        <\/script>
+    <script>
+        import { Loader } from '@svelteuidev/core';
+    <\/script>
 
-        <Loader \/>
+    <Loader \/>
     `;
     const variantLoaders = `
-        <script>
-            import { Loader } from '@svelteuidev/core';
-        <\/script>
+    <script>
+        import { Loader } from '@svelteuidev/core';
+    <\/script>
 
-        <Loader variant="circle" \/>
-        <Loader variant="dots" \/>
-        <Loader variant="bars" \/>
+    <Loader variant="circle" \/>
+    <Loader variant="dots" \/>
+    <Loader variant="bars" \/>
     `;
     const sizeLoaders = `
-        <script>
-            import { Loader } from '@svelteuidev/core';
-        <\/script>
+    <script>
+        import { Loader } from '@svelteuidev/core';
+    <\/script>
 
-        <Loader size="lg" \/>
-        <Loader size={50} \/>
+    <Loader size="lg" \/>
+    <Loader size={50} \/>
     `;
 </script>
 

--- a/docs/src/pages/core/switch.md
+++ b/docs/src/pages/core/switch.md
@@ -15,32 +15,32 @@ docs: 'core/switch.md'
     import { Heading, Preview } from 'components';
 
     const switchCode = `
-        <script>
-            import { Switch } from '@svelteuidev/core';
-        <\/script>
+    <script>
+        import { Switch } from '@svelteuidev/core';
+    <\/script>
 
-        <Switch label="I agree to sell my privacy" size="md" color="teal"\/>
-        <Switch onLabel="ON" offLabel="OFF" label="Setting 1" size="xl" color="pink"\/>
-        <Switch checked size="xs"\/>
+    <Switch label="I agree to sell my privacy" size="md" color="teal"\/>
+    <Switch onLabel="ON" offLabel="OFF" label="Setting 1" size="xl" color="pink"\/>
+    <Switch checked size="xs"\/>
     `;
     const labelSwitch = `
-        <script>
-            import { Switch } from '@svelteuidev/core';
-        <\/script>
+    <script>
+        import { Switch } from '@svelteuidev/core';
+    <\/script>
 
-        <Switch size='sm' onLabel="ON" offLabel="OFF" \/>
-        <Switch size='md' onLabel="ON" offLabel="OFF" \/>
-        <Switch size='lg' onLabel="ON" offLabel="OFF" \/>
-        <Switch size='xl' onLabel="ON" offLabel="OFF" \/>
+    <Switch size='sm' onLabel="ON" offLabel="OFF" \/>
+    <Switch size='md' onLabel="ON" offLabel="OFF" \/>
+    <Switch size='lg' onLabel="ON" offLabel="OFF" \/>
+    <Switch size='xl' onLabel="ON" offLabel="OFF" \/>
     `;
     const accessibilitySwitch = `
-        <script>
-            import { Switch } from '@svelteuidev/core';
-        <\/script>
+    <script>
+        import { Switch } from '@svelteuidev/core';
+    <\/script>
 
-        <Switch \/> // -> not ok, input is not labeled
-        <Switch label="I agree to everything" \/> // -> ok, input and label is connected
-        <Switch aria-label="I agree to everything" \/> // -> ok, label is not visible but will be announced by screen reader
+    <Switch \/> // -> not ok, input is not labeled
+    <Switch label="I agree to everything" \/> // -> ok, input and label is connected
+    <Switch aria-label="I agree to everything" \/> // -> ok, label is not visible but will be announced by screen reader
     `;
 </script>
 

--- a/docs/src/pages/core/text.md
+++ b/docs/src/pages/core/text.md
@@ -15,80 +15,80 @@ docs: 'core/text.md'
     import { Heading, Preview } from 'components';
 
     const text = `
-        <script>
-            import { Text } from '@svelteuidev/core';
-        <\/script>
+    <script>
+        import { Text } from '@svelteuidev/core';
+    <\/script>
 
-        <Text size="xs">Extra small text<\/Text>
-        <Text size="sm">Small text<\/Text>
-        <Text size="md">Default text<\/Text>
-        <Text size="lg">Large text<\/Text>
-        <Text size="xl">Extra large text<\/Text>
-        <Text weight={'semibold'}>Semibold<\/Text>
-        <Text weight={'bold'}>Bold<\/Text>
-        <Text underline>Underlined<\/Text>
-        <Text variant="link" root="a" href="https://svelteui-docs.vercel.app">Link variant<\/Text>
-        <Text color="red">Red text<\/Text>
-        <Text color="blue">Blue text<\/Text>
-        <Text color="gray">Gray text<\/Text>
-        <Text transform="uppercase">Uppercase<\/Text>
-        <Text transform="capitalize">capitalized text<\/Text>
-        <Text align="center">Aligned to center<\/Text>
-        <Text align="right">Aligned to right<\/Text>
+    <Text size="xs">Extra small text<\/Text>
+    <Text size="sm">Small text<\/Text>
+    <Text size="md">Default text<\/Text>
+    <Text size="lg">Large text<\/Text>
+    <Text size="xl">Extra large text<\/Text>
+    <Text weight={'semibold'}>Semibold<\/Text>
+    <Text weight={'bold'}>Bold<\/Text>
+    <Text underline>Underlined<\/Text>
+    <Text variant="link" root="a" href="https://svelteui-docs.vercel.app">Link variant<\/Text>
+    <Text color="red">Red text<\/Text>
+    <Text color="blue">Blue text<\/Text>
+    <Text color="gray">Gray text<\/Text>
+    <Text transform="uppercase">Uppercase<\/Text>
+    <Text transform="capitalize">capitalized text<\/Text>
+    <Text align="center">Aligned to center<\/Text>
+    <Text align="right">Aligned to right<\/Text>
     `;
     const dimmedText = `
-        <script>
-            import { Text } from '@svelteuidev/core';
-        <\/script>
+    <script>
+        import { Text } from '@svelteuidev/core';
+    <\/script>
 
-        <Text color="dimmed">Dimmed text<\/Text>
+    <Text color="dimmed">Dimmed text<\/Text>
     `;
     const gradientText = `
-        <script>
-            import { Text } from '@svelteuidev/core';
-        <\/script>
+    <script>
+        import { Text } from '@svelteuidev/core';
+    <\/script>
 
-        <Text
-            component="span"
-            align="center"
-            variant="gradient"
-            gradient={{ from: 'indigo', to: 'cyan', deg: 45 }}
-            size="xl"
-            weight={'bold'}
-        >
-            Indigo cyan gradient
-        <\/Text>
+    <Text
+        component="span"
+        align="center"
+        variant="gradient"
+        gradient={{ from: 'indigo', to: 'cyan', deg: 45 }}
+        size="xl"
+        weight={'bold'}
+    >
+        Indigo cyan gradient
+    <\/Text>
     `;
     const lineclampText = `
-        <script>
-            import { Text } from '@svelteuidev/core';
-        <\/script>
+    <script>
+        import { Text } from '@svelteuidev/core';
+    <\/script>
 
-        <Text lineClamp={4}>
-            From Bulbapedia: Bulbasaur is a small, quadrupedal Pokémon that has blue-green skin with darker patches. It has red eyes with white pupils, pointed, ear-like structures on top of its head, and a short, blunt snout with a wide mouth. A pair of small, pointed teeth are visible in the upper jaw when its mouth is open. Each of its thick legs ends with three sharp claws. On Bulbasaur's back is a green plant bulb, which is grown from a seed planted there at birth. The bulb also conceals two slender, tentacle-like vines.
-        <\/Text>
+    <Text lineClamp={4}>
+        From Bulbapedia: Bulbasaur is a small, quadrupedal Pokémon that has blue-green skin with darker patches. It has red eyes with white pupils, pointed, ear-like structures on top of its head, and a short, blunt snout with a wide mouth. A pair of small, pointed teeth are visible in the upper jaw when its mouth is open. Each of its thick legs ends with three sharp claws. On Bulbasaur's back is a green plant bulb, which is grown from a seed planted there at birth. The bulb also conceals two slender, tentacle-like vines.
+    <\/Text>
     `;
     const inheritText = `
-        <script>
-            import { Text, Title } from '@svelteuidev/core';
-        <\/script>
+    <script>
+        import { Text, Title } from '@svelteuidev/core';
+    <\/script>
 
-        <Title order={3}>
-            Highlight{' '}
-            <Text color="blue" inherit component="span">
-                something
-            <\/Text>
-            in title
-        <\/Title>
+    <Title order={3}>
+        Highlight{' '}
+        <Text color="blue" inherit component="span">
+            something
+        <\/Text>
+        in title
+    <\/Title>
     `;
     const customText = `
-        <script>
-            import { Code, Text } from '@svelteuidev/core';
-        <\/script>
+    <script>
+        import { Code, Text } from '@svelteuidev/core';
+    <\/script>
 
-        <Text root="a">This is a anchor now<\/Text>
-        <Text root="p">This is a paragraph<\/Text>
-        <Text root={Code}>This is a Code Component<\/Text>
+    <Text root="a">This is a anchor now<\/Text>
+    <Text root="p">This is a paragraph<\/Text>
+    <Text root={Code}>This is a Code Component<\/Text>
     `;
 </script>
 

--- a/docs/src/pages/core/title.md
+++ b/docs/src/pages/core/title.md
@@ -15,24 +15,24 @@ docs: 'core/title.md'
     import { Heading, Preview } from 'components';
 
     const title = `
-        <script>
-            import { Title } from '@svelteuidev/core';
-        <\/script>
+    <script>
+        import { Title } from '@svelteuidev/core';
+    <\/script>
 
-        <Title order={1}>This is h1 title<\/Title>
-        <Title order={2}>This is h2 title<\/Title>
-        <Title order={3}>This is h3 title<\/Title>
-        <Title order={4}>This is h4 title<\/Title>
-        <Title order={5}>This is h5 title<\/Title>
-        <Title order={6}>This is h6 title<\/Title>
+    <Title order={1}>This is h1 title<\/Title>
+    <Title order={2}>This is h2 title<\/Title>
+    <Title order={3}>This is h3 title<\/Title>
+    <Title order={4}>This is h4 title<\/Title>
+    <Title order={5}>This is h5 title<\/Title>
+    <Title order={6}>This is h6 title<\/Title>
     `;
     const sharedTitle = `
-        <script>
-            import { Title } from '@svelteuidev/core';
-        <\/script>
+    <script>
+        import { Title } from '@svelteuidev/core';
+    <\/script>
 
-        <Title order={1}>This is h1 title<\/Title>
-        <Title order={1} variant='gradient'>This is h1 title with a twist<\/Title>
+    <Title order={1}>This is h1 title<\/Title>
+    <Title order={1} variant='gradient'>This is h1 title with a twist<\/Title>
     `;
 </script>
 


### PR DESCRIPTION
Ported actions from previous documentation:
* use-click-outside
* use-css-variable
* use-download
* use-focus
* use-page-leave
* use-tab-leave

Ported utilities from previous documentation:
* os
* rafFn

![image](https://user-images.githubusercontent.com/25725586/167945364-eda5996f-0cf8-48db-9475-2ecda7d43704.png)

Also I formatted the code in components so that the spacing in the code is smaller on the left.

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `npm run lint` or just run `npm run repo:prepush` and check to see if it's passing.
