### PR TITLE
[@svelteui/core] Adapt button font size based on the prop `size`

### DIFF
--- a/packages/svelteui-core/src/lib/components/Button/Button.svelte
+++ b/packages/svelteui-core/src/lib/components/Button/Button.svelte
@@ -76,7 +76,7 @@
 		padding: sizes[compact ? `compact-${size}` : size].padding,
 		fontFamily: '$standard',
 		fontWeight: '$SemiBold',
-		fontSize: '$sm',
+		fontSize: `$${size}`,
 		lineHeight: 1,
 		flexGrow: 0,
 		width: fullSize ? '100%' : 'auto',


### PR DESCRIPTION
## Problem
Problem raised by @snake-345, in which the font size of the buttons was static and did not adapt with the size prop.

## Fix
* adapt `fontSize` according to the prop `size`

![image](https://user-images.githubusercontent.com/25725586/168487649-9a89c3f1-22b7-4ea8-ae44-d0900f8e12b2.png)


### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `npm run lint` or just run `npm run repo:prepush` and check to see if it's passing.
