### PR TITLE
[@svelteui/core] Anchor

### DIFF
--- a/packages/svelteui-core/src/lib/components/Anchor/Anchor.styles.ts
+++ b/packages/svelteui-core/src/lib/components/Anchor/Anchor.styles.ts
@@ -1,3 +1,8 @@
+import type { Override } from '$lib/styles';
 import type { TextProps } from '../Text/Text.styles';
 
-export interface AnchorProps extends TextProps {}
+export interface AnchorProps extends TextProps {
+	className: string;
+	override: Override['props'];
+	root: TextProps['root'];
+}

--- a/packages/svelteui-core/src/lib/components/Anchor/Anchor.styles.ts
+++ b/packages/svelteui-core/src/lib/components/Anchor/Anchor.styles.ts
@@ -1,0 +1,3 @@
+import type { TextProps } from '../Text/Text.styles';
+
+export interface AnchorProps extends TextProps {}

--- a/packages/svelteui-core/src/lib/components/Anchor/Anchor.svelte
+++ b/packages/svelteui-core/src/lib/components/Anchor/Anchor.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+	import { css } from '$lib/styles';
+	import Text from '../Text/Text.svelte';
+	import type { AnchorProps as $$AnchorProps } from './Anchor.styles';
+
+	/** Used for custom classes to be applied to the button e.g. Tailwind classes */
+	export let className: $$AnchorProps['className'] = '';
+	export { className as class };
+	/** Override prop for custom theming the component */
+	export let override: $$AnchorProps['override'] = {};
+    /** The component that is used as the anchor root */
+	export let root: $$AnchorProps['root'] = 'a';
+    /** The text variant to be used in the anchor */
+	export let variant: $$AnchorProps['variant'] = root === 'a' ? 'link' : null;
+
+	$: AnchorStyles = css({});
+	$: variant = root === 'a' ? 'link' : variant;
+</script>
+
+<!--
+@component
+**UNSTABLE:** new API, yet to be vetted.
+
+Display an anchor text that is a wrapper around `Text` component using an `a` as the default
+root.
+	
+@see https://svelteui.org/core/anchor
+@example
+    ```svelte
+    <Anchor href="https://svelteui.org/">Main Page</Anchor>
+    <Anchor root={Button} href="https://svelteui.org/" target="_blank">Documentation</Anchor>
+    <Anchor root={Link} to="/home" color='violet' size='lg'>Click here</Anchor>
+    ```
+-->
+<Text
+    class="{className} {AnchorStyles({ css: override })}"
+    root={root}
+    variant={variant}
+    {...$$restProps}
+>
+	<slot>Enter some anchor text</slot>
+</Text>

--- a/packages/svelteui-core/src/lib/components/Anchor/index.ts
+++ b/packages/svelteui-core/src/lib/components/Anchor/index.ts
@@ -1,0 +1,2 @@
+export { default as Anchor } from './Anchor.svelte';
+export * as AnchorStyles from './Anchor.styles';

--- a/packages/svelteui-core/src/lib/components/index.ts
+++ b/packages/svelteui-core/src/lib/components/index.ts
@@ -1,4 +1,5 @@
 export * from './ActionIcon';
+export * from './Anchor';
 export * from './Badge';
 export * from './Box';
 export * from './BrowserRender';

--- a/packages/svelteui-core/src/routes/index.svelte
+++ b/packages/svelteui-core/src/routes/index.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import {
 		ActionIcon,
+		Anchor,
 		BackgroundImage,
 		Button,
 		Checkbox,


### PR DESCRIPTION
Added `Anchor` component. Basically works as a link to a href or can integrate with a routing library by passing another `root` and the required props. Receives the same props as `Text`


```svelte
<Anchor href="https://svelteui.org/">Main Page</Anchor>
<Anchor href="https://svelteui.org/" color='lime' size='lg'>Main Page</Anchor>
```

![image](https://user-images.githubusercontent.com/25725586/168492608-963a61a4-4c0c-4fe0-8a47-cd069e15d638.png)

Docs will come in another PR

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `npm run lint` or just run `npm run repo:prepush` and check to see if it's passing.
