### PR TITLE
[core] add 'next' support for bump script

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "scripts": {
     "bump:major": "deno run --unstable --allow-read --allow-write ./scripts/bump.ts major",
     "bump:minor": "deno run --unstable --allow-read --allow-write ./scripts/bump.ts minor",
+    "bump:next": "deno run --unstable --allow-read --allow-write ./scripts/bump.ts next",
     "bump:patch": "deno run --unstable --allow-read --allow-write ./scripts/bump.ts patch",
     "clean": "rimraf packages/*/{node_modules,package,.turbo,types} packages/*/.svelte-kit/{generated,runtime,types}",
     "clean:all": "rimraf packages/*/{node_modules,.svelte-kit,package,.turbo,types}",

--- a/scripts/bump.ts
+++ b/scripts/bump.ts
@@ -15,7 +15,7 @@ const DIRS: string[] = [".", "./docs", "./packages/*/"];
 const VERSION_EXCEPTION: string[] = ["./docs"];
 
 if (Deno.args.length !== 1) {
-    throw "Please provide only one argument, the type of version bump ('major', 'minor' or 'patch')"
+    throw "Please provide only one argument, the type of version bump ('major', 'minor', 'patch' or 'next')"
 }
 
 const type = Deno.args[0] as SEMVER;

--- a/scripts/utils/version.ts
+++ b/scripts/utils/version.ts
@@ -1,19 +1,26 @@
 export function calculateVersion(type: string, version: string): string {
-    let newVersion = version.split(".").map(p => parseInt(p));
+    const versionParts = version.split("-");
+    let newVersion = versionParts[0].split(".").map(p => parseInt(p));
+    let nextPart = versionParts[1] ? versionParts[1].split('.') : [];
+
     switch (type) {
         case "major":
             newVersion = [newVersion[0] + 1, 0, 0];
-            break;
+            return newVersion.join(".");
         case "minor":
             newVersion = [newVersion[0], newVersion[1] + 1, 0];
-            break;
+            return newVersion.join(".");
         case "patch":
             newVersion = [newVersion[0], newVersion[1], newVersion[2] +1];
-            break;
+            return newVersion.join(".");
+        case "next":
+            nextPart = nextPart.length === 0
+                ? ["next", "1"]
+                : ["next", String(parseInt(nextPart[1]) + 1)];
+            return [newVersion.join("."), nextPart.join(".")].join("-");
         default:
-            throw "Please provide one of these values: 'major', 'minor' or 'patch'"
+            throw "Please provide one of these values: 'major', 'minor', 'patch' or 'next'"
     }
-    return newVersion.join(".");
 }
 
 export function updateVersions(version: string, packageJSON: Record<string, any>, skipPackageBump: boolean): Record<string, any> {


### PR DESCRIPTION
Added npm  script `bump:next` that supports bumping all packages to a next version.
Behaviour:

0.6.2 -> 0.6.2-next.1 | bump:next
0.6.2-next.1 -> 0.6.2-next.2 | bump:next

0.6.2-next.2  -> 0.6.3 | bump:patch
0.6.2-next.2  -> 0.7.0 | bump:minor
0.6.2-next.2  -> 1.0.0 | bump:major

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `npm run lint` or just run `npm run repo:prepush` and check to see if it's passing.
