### PR TITLE
[core] fix imports and support for watching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6891,7 +6891,6 @@
       "version": "3.48.0",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.48.0.tgz",
       "integrity": "sha512-fN2YRm/bGumvjUpu6yI3BpvZnpIm9I6A7HR4oUNYd7ggYyIwSA/BX7DJ+UXXffLp6XNcUijyLvttbPVCYa/3xQ==",
-      "peer": true,
       "engines": {
         "node": ">= 8"
       }
@@ -8247,13 +8246,13 @@
         "@stitches/core": "1.2.8"
       },
       "devDependencies": {
-        "@sveltejs/kit": "1.0.0-next.310",
+        "@sveltejs/kit": "1.0.0-next.333",
         "@svelteuidev/tsconfig": "^*",
         "autoprefixer": "10.4.4",
         "cssnano": "5.1.7",
         "postcss": "8.4.12",
         "sass": "1.50.0",
-        "svelte": "3.47.0",
+        "svelte": "3.48.0",
         "svelte-check": "2.2.6",
         "svelte-preprocess": "4.10.5",
         "svelte2tsx": "0.5.7",
@@ -8263,6 +8262,27 @@
       "peerDependencies": {
         "@svelteuidev/actions": "0.6.2",
         "svelte": "3.47.0"
+      }
+    },
+    "packages/svelteui-core/node_modules/@sveltejs/kit": {
+      "version": "1.0.0-next.333",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.333.tgz",
+      "integrity": "sha512-gaj68NCVVKnzDPALzNbaP2xMaNvCZYxoreEGF6P8/bPAh4X6yB5OrgmtensoizPxSJW6d/Lz4LVw71LPmrQgkw==",
+      "dev": true,
+      "dependencies": {
+        "@sveltejs/vite-plugin-svelte": "^1.0.0-next.32",
+        "chokidar": "^3.5.3",
+        "sade": "^1.7.4",
+        "vite": "^2.9.0"
+      },
+      "bin": {
+        "svelte-kit": "svelte-kit.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "svelte": "^3.44.0"
       }
     },
     "packages/svelteui-core/node_modules/ansi-styles": {
@@ -8342,15 +8362,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "packages/svelteui-core/node_modules/svelte": {
-      "version": "3.47.0",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.47.0.tgz",
-      "integrity": "sha512-4JaJp3HEoTCGARRWZQIZDUanhYv0iyoHikklVHVLH9xFE9db22g4TDv7CPeNA8HD1JgjXI1vlhR1JZvvhaTu2Q==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
       }
     },
     "packages/svelteui-core/node_modules/svelte-check": {
@@ -8516,6 +8527,13 @@
       "name": "@svelteuidev/demos",
       "version": "0.6.2",
       "license": "MIT",
+      "dependencies": {
+        "@svelteuidev/actions": "0.6.2",
+        "@svelteuidev/core": "0.6.2",
+        "@svelteuidev/motion": "0.6.2",
+        "@svelteuidev/prism": "0.6.2",
+        "@svelteuidev/utilities": "0.6.2"
+      },
       "devDependencies": {
         "@sveltejs/kit": "1.0.0-next.310",
         "@svelteuidev/tsconfig": "^*",
@@ -8523,19 +8541,12 @@
         "cssnano": "5.1.7",
         "postcss": "8.4.12",
         "sass": "1.50.0",
-        "svelte": "3.47.0",
+        "svelte": "3.48.0",
         "svelte-check": "2.2.6",
         "svelte-preprocess": "4.10.5",
         "svelte2tsx": "0.5.7",
         "tslib": "2.3.1",
         "typescript": "4.6.3"
-      },
-      "peerDependencies": {
-        "@svelteuidev/actions": "0.6.2",
-        "@svelteuidev/core": "0.6.2",
-        "@svelteuidev/motion": "0.6.2",
-        "@svelteuidev/prism": "0.6.2",
-        "@svelteuidev/utilities": "0.6.2"
       }
     },
     "packages/svelteui-demos/node_modules/ansi-styles": {
@@ -8615,15 +8626,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "packages/svelteui-demos/node_modules/svelte": {
-      "version": "3.47.0",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.47.0.tgz",
-      "integrity": "sha512-4JaJp3HEoTCGARRWZQIZDUanhYv0iyoHikklVHVLH9xFE9db22g4TDv7CPeNA8HD1JgjXI1vlhR1JZvvhaTu2Q==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
       }
     },
     "packages/svelteui-demos/node_modules/svelte-check": {
@@ -9235,13 +9237,13 @@
       "version": "file:packages/svelteui-core",
       "requires": {
         "@stitches/core": "1.2.8",
-        "@sveltejs/kit": "1.0.0-next.310",
+        "@sveltejs/kit": "1.0.0-next.333",
         "@svelteuidev/tsconfig": "^*",
         "autoprefixer": "10.4.4",
         "cssnano": "5.1.7",
         "postcss": "8.4.12",
         "sass": "1.50.0",
-        "svelte": "3.47.0",
+        "svelte": "3.48.0",
         "svelte-check": "2.2.6",
         "svelte-preprocess": "4.10.5",
         "svelte2tsx": "0.5.7",
@@ -9249,6 +9251,18 @@
         "typescript": "4.6.3"
       },
       "dependencies": {
+        "@sveltejs/kit": {
+          "version": "1.0.0-next.333",
+          "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.333.tgz",
+          "integrity": "sha512-gaj68NCVVKnzDPALzNbaP2xMaNvCZYxoreEGF6P8/bPAh4X6yB5OrgmtensoizPxSJW6d/Lz4LVw71LPmrQgkw==",
+          "dev": true,
+          "requires": {
+            "@sveltejs/vite-plugin-svelte": "^1.0.0-next.32",
+            "chokidar": "^3.5.3",
+            "sade": "^1.7.4",
+            "vite": "^2.9.0"
+          }
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -9303,12 +9317,6 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
-        },
-        "svelte": {
-          "version": "3.47.0",
-          "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.47.0.tgz",
-          "integrity": "sha512-4JaJp3HEoTCGARRWZQIZDUanhYv0iyoHikklVHVLH9xFE9db22g4TDv7CPeNA8HD1JgjXI1vlhR1JZvvhaTu2Q==",
-          "dev": true
         },
         "svelte-check": {
           "version": "2.2.6",
@@ -9431,12 +9439,17 @@
       "version": "file:packages/svelteui-demos",
       "requires": {
         "@sveltejs/kit": "1.0.0-next.310",
+        "@svelteuidev/actions": "0.6.2",
+        "@svelteuidev/core": "0.6.2",
+        "@svelteuidev/motion": "0.6.2",
+        "@svelteuidev/prism": "0.6.2",
         "@svelteuidev/tsconfig": "^*",
+        "@svelteuidev/utilities": "0.6.2",
         "autoprefixer": "10.4.4",
         "cssnano": "5.1.7",
         "postcss": "8.4.12",
         "sass": "1.50.0",
-        "svelte": "3.47.0",
+        "svelte": "3.48.0",
         "svelte-check": "2.2.6",
         "svelte-preprocess": "4.10.5",
         "svelte2tsx": "0.5.7",
@@ -9498,12 +9511,6 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
-        },
-        "svelte": {
-          "version": "3.47.0",
-          "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.47.0.tgz",
-          "integrity": "sha512-4JaJp3HEoTCGARRWZQIZDUanhYv0iyoHikklVHVLH9xFE9db22g4TDv7CPeNA8HD1JgjXI1vlhR1JZvvhaTu2Q==",
-          "dev": true
         },
         "svelte-check": {
           "version": "2.2.6",
@@ -14129,8 +14136,7 @@
     "svelte": {
       "version": "3.48.0",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.48.0.tgz",
-      "integrity": "sha512-fN2YRm/bGumvjUpu6yI3BpvZnpIm9I6A7HR4oUNYd7ggYyIwSA/BX7DJ+UXXffLp6XNcUijyLvttbPVCYa/3xQ==",
-      "peer": true
+      "integrity": "sha512-fN2YRm/bGumvjUpu6yI3BpvZnpIm9I6A7HR4oUNYd7ggYyIwSA/BX7DJ+UXXffLp6XNcUijyLvttbPVCYa/3xQ=="
     },
     "svelte-check": {
       "version": "2.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -524,12 +524,13 @@
       "integrity": "sha512-Gfkvwk9o9kE9r9XNBmJRfV8zONvXThnm1tcuojL04Uy5uRyqg93DC83lDebl0rocZCfKSjUv+fWYtMQmEDJldg=="
     },
     "node_modules/@sveltejs/kit": {
-      "version": "1.0.0-next.310",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.310.tgz",
-      "integrity": "sha512-pTyMyaoyHS+V5cQZIQMfQXmLkhw1VaRwT9avOSgwDc0QBpnNw2LdzwoPYsUr96ca5B6cfT3SMUNolxErTNHmPQ==",
+      "version": "1.0.0-next.333",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.333.tgz",
+      "integrity": "sha512-gaj68NCVVKnzDPALzNbaP2xMaNvCZYxoreEGF6P8/bPAh4X6yB5OrgmtensoizPxSJW6d/Lz4LVw71LPmrQgkw==",
       "dev": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte": "^1.0.0-next.32",
+        "chokidar": "^3.5.3",
         "sade": "^1.7.4",
         "vite": "^2.9.0"
       },
@@ -537,7 +538,7 @@
         "svelte-kit": "svelte-kit.js"
       },
       "engines": {
-        "node": ">=14.13"
+        "node": ">=16"
       },
       "peerDependencies": {
         "svelte": "^3.44.0"
@@ -8213,7 +8214,7 @@
       "version": "0.6.2",
       "license": "MIT",
       "devDependencies": {
-        "@sveltejs/kit": "1.0.0-next.310",
+        "@sveltejs/kit": "1.0.0-next.333",
         "@svelteuidev/tsconfig": "^*",
         "@testing-library/svelte": "3.1.1",
         "autoprefixer": "10.4.4",
@@ -8221,21 +8222,12 @@
         "jsdom": "19.0.0",
         "postcss": "8.4.12",
         "sass": "1.50.0",
-        "svelte": "3.47.0",
+        "svelte": "3.48.0",
         "svelte-check": "2.5.0",
         "svelte-preprocess": "4.10.5",
         "svelte2tsx": "0.5.7",
         "tslib": "2.3.1",
         "typescript": "4.6.3"
-      }
-    },
-    "packages/svelteui-actions/node_modules/svelte": {
-      "version": "3.47.0",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.47.0.tgz",
-      "integrity": "sha512-4JaJp3HEoTCGARRWZQIZDUanhYv0iyoHikklVHVLH9xFE9db22g4TDv7CPeNA8HD1JgjXI1vlhR1JZvvhaTu2Q==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
       }
     },
     "packages/svelteui-core": {
@@ -8262,27 +8254,6 @@
       "peerDependencies": {
         "@svelteuidev/actions": "0.6.2",
         "svelte": "3.47.0"
-      }
-    },
-    "packages/svelteui-core/node_modules/@sveltejs/kit": {
-      "version": "1.0.0-next.333",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.333.tgz",
-      "integrity": "sha512-gaj68NCVVKnzDPALzNbaP2xMaNvCZYxoreEGF6P8/bPAh4X6yB5OrgmtensoizPxSJW6d/Lz4LVw71LPmrQgkw==",
-      "dev": true,
-      "dependencies": {
-        "@sveltejs/vite-plugin-svelte": "^1.0.0-next.32",
-        "chokidar": "^3.5.3",
-        "sade": "^1.7.4",
-        "vite": "^2.9.0"
-      },
-      "bin": {
-        "svelte-kit": "svelte-kit.js"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "svelte": "^3.44.0"
       }
     },
     "packages/svelteui-core/node_modules/ansi-styles": {
@@ -8395,13 +8366,13 @@
         "dayjs": "1.11.1"
       },
       "devDependencies": {
-        "@sveltejs/kit": "1.0.0-next.310",
+        "@sveltejs/kit": "1.0.0-next.333",
         "@svelteuidev/tsconfig": "^*",
         "autoprefixer": "10.4.4",
         "cssnano": "5.1.7",
         "postcss": "8.4.12",
         "sass": "1.50.0",
-        "svelte": "3.47.0",
+        "svelte": "3.48.0",
         "svelte-check": "2.2.6",
         "svelte-preprocess": "4.10.5",
         "svelte2tsx": "0.5.7",
@@ -8491,15 +8462,6 @@
         "node": ">=8"
       }
     },
-    "packages/svelteui-dates/node_modules/svelte": {
-      "version": "3.47.0",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.47.0.tgz",
-      "integrity": "sha512-4JaJp3HEoTCGARRWZQIZDUanhYv0iyoHikklVHVLH9xFE9db22g4TDv7CPeNA8HD1JgjXI1vlhR1JZvvhaTu2Q==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "packages/svelteui-dates/node_modules/svelte-check": {
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-2.2.6.tgz",
@@ -8535,7 +8497,7 @@
         "@svelteuidev/utilities": "0.6.2"
       },
       "devDependencies": {
-        "@sveltejs/kit": "1.0.0-next.310",
+        "@sveltejs/kit": "1.0.0-next.333",
         "@svelteuidev/tsconfig": "^*",
         "autoprefixer": "10.4.4",
         "cssnano": "5.1.7",
@@ -8656,27 +8618,18 @@
       "version": "0.6.2",
       "license": "MIT",
       "devDependencies": {
-        "@sveltejs/kit": "1.0.0-next.310",
+        "@sveltejs/kit": "1.0.0-next.333",
         "@svelteuidev/tsconfig": "^*",
         "autoprefixer": "10.4.4",
         "cssnano": "5.1.7",
         "postcss": "8.4.12",
         "sass": "1.50.0",
-        "svelte": "3.47.0",
+        "svelte": "3.48.0",
         "svelte-check": "2.5.0",
         "svelte-preprocess": "4.10.5",
         "svelte2tsx": "0.5.7",
         "tslib": "2.3.1",
         "typescript": "4.6.3"
-      }
-    },
-    "packages/svelteui-motion/node_modules/svelte": {
-      "version": "3.47.0",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.47.0.tgz",
-      "integrity": "sha512-4JaJp3HEoTCGARRWZQIZDUanhYv0iyoHikklVHVLH9xFE9db22g4TDv7CPeNA8HD1JgjXI1vlhR1JZvvhaTu2Q==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
       }
     },
     "packages/svelteui-prism": {
@@ -8690,13 +8643,13 @@
         "prismjs": "1.28.0"
       },
       "devDependencies": {
-        "@sveltejs/kit": "1.0.0-next.310",
+        "@sveltejs/kit": "1.0.0-next.333",
         "@svelteuidev/tsconfig": "^*",
         "autoprefixer": "10.4.4",
         "cssnano": "5.1.7",
         "postcss": "8.4.12",
         "sass": "1.50.0",
-        "svelte": "3.47.0",
+        "svelte": "3.48.0",
         "svelte-check": "2.5.0",
         "svelte-preprocess": "4.10.5",
         "svelte2tsx": "0.5.7",
@@ -8709,42 +8662,24 @@
         "svelte": "3.47.0"
       }
     },
-    "packages/svelteui-prism/node_modules/svelte": {
-      "version": "3.47.0",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.47.0.tgz",
-      "integrity": "sha512-4JaJp3HEoTCGARRWZQIZDUanhYv0iyoHikklVHVLH9xFE9db22g4TDv7CPeNA8HD1JgjXI1vlhR1JZvvhaTu2Q==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "packages/svelteui-utilities": {
       "name": "@svelteuidev/utilities",
       "version": "0.6.2",
       "license": "MIT",
       "devDependencies": {
-        "@sveltejs/kit": "1.0.0-next.310",
+        "@sveltejs/kit": "1.0.0-next.333",
         "@svelteuidev/tsconfig": "^*",
         "autoprefixer": "10.4.4",
         "cssnano": "5.1.7",
         "jsdom": "19.0.0",
         "postcss": "8.4.12",
         "sass": "1.50.0",
-        "svelte": "3.47.0",
+        "svelte": "3.48.0",
         "svelte-check": "2.5.0",
         "svelte-preprocess": "4.10.5",
         "svelte2tsx": "0.5.7",
         "tslib": "2.3.1",
         "typescript": "4.6.3"
-      }
-    },
-    "packages/svelteui-utilities/node_modules/svelte": {
-      "version": "3.47.0",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.47.0.tgz",
-      "integrity": "sha512-4JaJp3HEoTCGARRWZQIZDUanhYv0iyoHikklVHVLH9xFE9db22g4TDv7CPeNA8HD1JgjXI1vlhR1JZvvhaTu2Q==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
       }
     }
   },
@@ -9183,12 +9118,13 @@
       "integrity": "sha512-Gfkvwk9o9kE9r9XNBmJRfV8zONvXThnm1tcuojL04Uy5uRyqg93DC83lDebl0rocZCfKSjUv+fWYtMQmEDJldg=="
     },
     "@sveltejs/kit": {
-      "version": "1.0.0-next.310",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.310.tgz",
-      "integrity": "sha512-pTyMyaoyHS+V5cQZIQMfQXmLkhw1VaRwT9avOSgwDc0QBpnNw2LdzwoPYsUr96ca5B6cfT3SMUNolxErTNHmPQ==",
+      "version": "1.0.0-next.333",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.333.tgz",
+      "integrity": "sha512-gaj68NCVVKnzDPALzNbaP2xMaNvCZYxoreEGF6P8/bPAh4X6yB5OrgmtensoizPxSJW6d/Lz4LVw71LPmrQgkw==",
       "dev": true,
       "requires": {
         "@sveltejs/vite-plugin-svelte": "^1.0.0-next.32",
+        "chokidar": "^3.5.3",
         "sade": "^1.7.4",
         "vite": "^2.9.0"
       }
@@ -9209,7 +9145,7 @@
     "@svelteuidev/actions": {
       "version": "file:packages/svelteui-actions",
       "requires": {
-        "@sveltejs/kit": "1.0.0-next.310",
+        "@sveltejs/kit": "1.0.0-next.333",
         "@svelteuidev/tsconfig": "^*",
         "@testing-library/svelte": "3.1.1",
         "autoprefixer": "10.4.4",
@@ -9217,20 +9153,12 @@
         "jsdom": "19.0.0",
         "postcss": "8.4.12",
         "sass": "1.50.0",
-        "svelte": "3.47.0",
+        "svelte": "3.48.0",
         "svelte-check": "2.5.0",
         "svelte-preprocess": "4.10.5",
         "svelte2tsx": "0.5.7",
         "tslib": "2.3.1",
         "typescript": "4.6.3"
-      },
-      "dependencies": {
-        "svelte": {
-          "version": "3.47.0",
-          "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.47.0.tgz",
-          "integrity": "sha512-4JaJp3HEoTCGARRWZQIZDUanhYv0iyoHikklVHVLH9xFE9db22g4TDv7CPeNA8HD1JgjXI1vlhR1JZvvhaTu2Q==",
-          "dev": true
-        }
       }
     },
     "@svelteuidev/core": {
@@ -9251,18 +9179,6 @@
         "typescript": "4.6.3"
       },
       "dependencies": {
-        "@sveltejs/kit": {
-          "version": "1.0.0-next.333",
-          "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.333.tgz",
-          "integrity": "sha512-gaj68NCVVKnzDPALzNbaP2xMaNvCZYxoreEGF6P8/bPAh4X6yB5OrgmtensoizPxSJW6d/Lz4LVw71LPmrQgkw==",
-          "dev": true,
-          "requires": {
-            "@sveltejs/vite-plugin-svelte": "^1.0.0-next.32",
-            "chokidar": "^3.5.3",
-            "sade": "^1.7.4",
-            "vite": "^2.9.0"
-          }
-        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -9340,14 +9256,14 @@
     "@svelteuidev/dates": {
       "version": "file:packages/svelteui-dates",
       "requires": {
-        "@sveltejs/kit": "1.0.0-next.310",
+        "@sveltejs/kit": "1.0.0-next.333",
         "@svelteuidev/tsconfig": "^*",
         "autoprefixer": "10.4.4",
         "cssnano": "5.1.7",
         "dayjs": "1.11.1",
         "postcss": "8.4.12",
         "sass": "1.50.0",
-        "svelte": "3.47.0",
+        "svelte": "3.48.0",
         "svelte-check": "2.2.6",
         "svelte-preprocess": "4.10.5",
         "svelte2tsx": "0.5.7",
@@ -9410,12 +9326,6 @@
             "has-flag": "^4.0.0"
           }
         },
-        "svelte": {
-          "version": "3.47.0",
-          "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.47.0.tgz",
-          "integrity": "sha512-4JaJp3HEoTCGARRWZQIZDUanhYv0iyoHikklVHVLH9xFE9db22g4TDv7CPeNA8HD1JgjXI1vlhR1JZvvhaTu2Q==",
-          "dev": true
-        },
         "svelte-check": {
           "version": "2.2.6",
           "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-2.2.6.tgz",
@@ -9438,7 +9348,7 @@
     "@svelteuidev/demos": {
       "version": "file:packages/svelteui-demos",
       "requires": {
-        "@sveltejs/kit": "1.0.0-next.310",
+        "@sveltejs/kit": "1.0.0-next.333",
         "@svelteuidev/actions": "0.6.2",
         "@svelteuidev/core": "0.6.2",
         "@svelteuidev/motion": "0.6.2",
@@ -9534,32 +9444,24 @@
     "@svelteuidev/motion": {
       "version": "file:packages/svelteui-motion",
       "requires": {
-        "@sveltejs/kit": "1.0.0-next.310",
+        "@sveltejs/kit": "1.0.0-next.333",
         "@svelteuidev/tsconfig": "^*",
         "autoprefixer": "10.4.4",
         "cssnano": "5.1.7",
         "postcss": "8.4.12",
         "sass": "1.50.0",
-        "svelte": "3.47.0",
+        "svelte": "3.48.0",
         "svelte-check": "2.5.0",
         "svelte-preprocess": "4.10.5",
         "svelte2tsx": "0.5.7",
         "tslib": "2.3.1",
         "typescript": "4.6.3"
-      },
-      "dependencies": {
-        "svelte": {
-          "version": "3.47.0",
-          "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.47.0.tgz",
-          "integrity": "sha512-4JaJp3HEoTCGARRWZQIZDUanhYv0iyoHikklVHVLH9xFE9db22g4TDv7CPeNA8HD1JgjXI1vlhR1JZvvhaTu2Q==",
-          "dev": true
-        }
       }
     },
     "@svelteuidev/prism": {
       "version": "file:packages/svelteui-prism",
       "requires": {
-        "@sveltejs/kit": "1.0.0-next.310",
+        "@sveltejs/kit": "1.0.0-next.333",
         "@svelteuidev/actions": "0.6.2",
         "@svelteuidev/core": "0.6.2",
         "@svelteuidev/tsconfig": "^*",
@@ -9569,20 +9471,12 @@
         "prism-svelte": "0.5.0",
         "prismjs": "1.28.0",
         "sass": "1.50.0",
-        "svelte": "3.47.0",
+        "svelte": "3.48.0",
         "svelte-check": "2.5.0",
         "svelte-preprocess": "4.10.5",
         "svelte2tsx": "0.5.7",
         "tslib": "2.3.1",
         "typescript": "4.6.3"
-      },
-      "dependencies": {
-        "svelte": {
-          "version": "3.47.0",
-          "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.47.0.tgz",
-          "integrity": "sha512-4JaJp3HEoTCGARRWZQIZDUanhYv0iyoHikklVHVLH9xFE9db22g4TDv7CPeNA8HD1JgjXI1vlhR1JZvvhaTu2Q==",
-          "dev": true
-        }
       }
     },
     "@svelteuidev/tsconfig": {
@@ -9591,27 +9485,19 @@
     "@svelteuidev/utilities": {
       "version": "file:packages/svelteui-utilities",
       "requires": {
-        "@sveltejs/kit": "1.0.0-next.310",
+        "@sveltejs/kit": "1.0.0-next.333",
         "@svelteuidev/tsconfig": "^*",
         "autoprefixer": "10.4.4",
         "cssnano": "5.1.7",
         "jsdom": "19.0.0",
         "postcss": "8.4.12",
         "sass": "1.50.0",
-        "svelte": "3.47.0",
+        "svelte": "3.48.0",
         "svelte-check": "2.5.0",
         "svelte-preprocess": "4.10.5",
         "svelte2tsx": "0.5.7",
         "tslib": "2.3.1",
         "typescript": "4.6.3"
-      },
-      "dependencies": {
-        "svelte": {
-          "version": "3.47.0",
-          "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.47.0.tgz",
-          "integrity": "sha512-4JaJp3HEoTCGARRWZQIZDUanhYv0iyoHikklVHVLH9xFE9db22g4TDv7CPeNA8HD1JgjXI1vlhR1JZvvhaTu2Q==",
-          "dev": true
-        }
       }
     },
     "@testing-library/dom": {

--- a/packages/svelteui-actions/package.json
+++ b/packages/svelteui-actions/package.json
@@ -23,6 +23,7 @@
   "author": "Kamell Perry <kamellperry33@gmail.com>",
   "sideEffects": false,
   "type": "module",
+  "module": "./package/index.js",
   "types": "types/index.d.ts",
   "files": [
     "index.js",
@@ -41,10 +42,11 @@
     "pub:test": "npm publish package/",
     "sort": "npx sort-package-json",
     "test": "vitest --run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "watch": "svelte-kit package -w"
   },
   "devDependencies": {
-    "@sveltejs/kit": "1.0.0-next.310",
+    "@sveltejs/kit": "1.0.0-next.333",
     "@svelteuidev/tsconfig": "^*",
     "@testing-library/svelte": "3.1.1",
     "autoprefixer": "10.4.4",
@@ -52,7 +54,7 @@
     "jsdom": "19.0.0",
     "postcss": "8.4.12",
     "sass": "1.50.0",
-    "svelte": "3.47.0",
+    "svelte": "3.48.0",
     "svelte-check": "2.5.0",
     "svelte-preprocess": "4.10.5",
     "svelte2tsx": "0.5.7",

--- a/packages/svelteui-core/package.json
+++ b/packages/svelteui-core/package.json
@@ -24,11 +24,8 @@
   "author": "Kamell Perry <kamellperry33@gmail.com>",
   "sideEffects": false,
   "type": "module",
-  "exports": {
-    ".": "./index.js",
-    "./package.json": "./package.json"
-  },
   "main": "index.js",
+  "module": "./package/index.js",
   "types": "types/index.d.ts",
   "files": [
     "index.js",
@@ -47,19 +44,20 @@
     "package": "svelte-kit package",
     "pub": "npm publish package/",
     "pub:test": "npm publish package/",
-    "sort": "npx sort-package-json"
+    "sort": "npx sort-package-json",
+    "watch": "svelte-kit package -w"
   },
   "dependencies": {
     "@stitches/core": "1.2.8"
   },
   "devDependencies": {
-    "@sveltejs/kit": "1.0.0-next.310",
+    "@sveltejs/kit": "1.0.0-next.333",
     "@svelteuidev/tsconfig": "^*",
     "autoprefixer": "10.4.4",
     "cssnano": "5.1.7",
     "postcss": "8.4.12",
     "sass": "1.50.0",
-    "svelte": "3.47.0",
+    "svelte": "3.48.0",
     "svelte-check": "2.2.6",
     "svelte-preprocess": "4.10.5",
     "svelte2tsx": "0.5.7",

--- a/packages/svelteui-dates/package.json
+++ b/packages/svelteui-dates/package.json
@@ -26,6 +26,7 @@
   "author": "Kamell Perry <kamellperry33@gmail.com>",
   "sideEffects": false,
   "type": "module",
+  "module": "./package/index.js",
   "types": "types/index.d.ts",
   "files": [
     "index.js",
@@ -42,19 +43,20 @@
     "package": "svelte-kit package",
     "pub": "npm publish package/",
     "pub:test": "npm publish package/",
-    "sort": "npx sort-package-json"
+    "sort": "npx sort-package-json",
+    "watch": "svelte-kit package -w"
   },
   "dependencies": {
     "dayjs": "1.11.1"
   },
   "devDependencies": {
-    "@sveltejs/kit": "1.0.0-next.310",
+    "@sveltejs/kit": "1.0.0-next.333",
     "@svelteuidev/tsconfig": "^*",
     "autoprefixer": "10.4.4",
     "cssnano": "5.1.7",
     "postcss": "8.4.12",
     "sass": "1.50.0",
-    "svelte": "3.47.0",
+    "svelte": "3.48.0",
     "svelte-check": "2.2.6",
     "svelte-preprocess": "4.10.5",
     "svelte2tsx": "0.5.7",

--- a/packages/svelteui-demos/package.json
+++ b/packages/svelteui-demos/package.json
@@ -24,6 +24,7 @@
   "author": "Kamell Perry <kamellperry33@gmail.com>",
   "sideEffects": false,
   "type": "module",
+  "module": "./package/index.js",
   "types": "types/index.d.ts",
   "files": [
     "index.js",
@@ -40,28 +41,28 @@
     "package": "svelte-kit package",
     "pub": "npm publish package/",
     "pub:test": "npm publish package/",
-    "sort": "npx sort-package-json"
+    "sort": "npx sort-package-json",
+    "watch": "svelte-kit package -w"
   },
-  "dependencies": {},
-  "devDependencies": {
-    "@sveltejs/kit": "1.0.0-next.310",
-    "@svelteuidev/tsconfig": "^*",
-    "autoprefixer": "10.4.4",
-    "cssnano": "5.1.7",
-    "postcss": "8.4.12",
-    "sass": "1.50.0",
-    "svelte": "3.47.0",
-    "svelte-check": "2.2.6",
-    "svelte-preprocess": "4.10.5",
-    "svelte2tsx": "0.5.7",
-    "tslib": "2.3.1",
-    "typescript": "4.6.3"
-  },
-  "peerDependencies": {
+  "dependencies": {
     "@svelteuidev/actions": "0.6.2",
     "@svelteuidev/core": "0.6.2",
     "@svelteuidev/motion": "0.6.2",
     "@svelteuidev/prism": "0.6.2",
     "@svelteuidev/utilities": "0.6.2"
+  },
+  "devDependencies": {
+    "@sveltejs/kit": "1.0.0-next.333",
+    "@svelteuidev/tsconfig": "^*",
+    "autoprefixer": "10.4.4",
+    "cssnano": "5.1.7",
+    "postcss": "8.4.12",
+    "sass": "1.50.0",
+    "svelte": "3.48.0",
+    "svelte-check": "2.2.6",
+    "svelte-preprocess": "4.10.5",
+    "svelte2tsx": "0.5.7",
+    "tslib": "2.3.1",
+    "typescript": "4.6.3"
   }
 }

--- a/packages/svelteui-motion/package.json
+++ b/packages/svelteui-motion/package.json
@@ -24,6 +24,7 @@
   "author": "Kamell Perry <kamellperry33@gmail.com>",
   "sideEffects": false,
   "type": "module",
+  "module": "./package/index.js",
   "types": "types/index.d.ts",
   "files": [
     "index.js",
@@ -39,16 +40,17 @@
     "package": "svelte-kit package",
     "pub": "npm publish package/",
     "pub:test": "npm publish package/",
-    "sort": "npx sort-package-json"
+    "sort": "npx sort-package-json",
+    "watch": "svelte-kit package -w"
   },
   "devDependencies": {
-    "@sveltejs/kit": "1.0.0-next.310",
+    "@sveltejs/kit": "1.0.0-next.333",
     "@svelteuidev/tsconfig": "^*",
     "autoprefixer": "10.4.4",
     "cssnano": "5.1.7",
     "postcss": "8.4.12",
     "sass": "1.50.0",
-    "svelte": "3.47.0",
+    "svelte": "3.48.0",
     "svelte-check": "2.5.0",
     "svelte-preprocess": "4.10.5",
     "svelte2tsx": "0.5.7",

--- a/packages/svelteui-prism/package.json
+++ b/packages/svelteui-prism/package.json
@@ -25,6 +25,7 @@
   "author": "Kamell Perry <kamellperry33@gmail.com>",
   "sideEffects": false,
   "type": "module",
+  "module": "./package/index.js",
   "types": "types/index.d.ts",
   "files": [
     "index.js",
@@ -40,7 +41,8 @@
     "package": "svelte-kit package",
     "pub": "npm publish package/",
     "pub:test": "npm publish package/",
-    "sort": "npx sort-package-json"
+    "sort": "npx sort-package-json",
+    "watch": "svelte-kit package -w"
   },
   "dependencies": {
     "@svelteuidev/actions": "0.6.2",
@@ -49,13 +51,13 @@
     "prismjs": "1.28.0"
   },
   "devDependencies": {
-    "@sveltejs/kit": "1.0.0-next.310",
+    "@sveltejs/kit": "1.0.0-next.333",
     "@svelteuidev/tsconfig": "^*",
     "autoprefixer": "10.4.4",
     "cssnano": "5.1.7",
     "postcss": "8.4.12",
     "sass": "1.50.0",
-    "svelte": "3.47.0",
+    "svelte": "3.48.0",
     "svelte-check": "2.5.0",
     "svelte-preprocess": "4.10.5",
     "svelte2tsx": "0.5.7",

--- a/packages/svelteui-utilities/package.json
+++ b/packages/svelteui-utilities/package.json
@@ -23,8 +23,7 @@
   "author": "Kamell Perry <kamellperry33@gmail.com>",
   "sideEffects": false,
   "type": "module",
-  "main": "index.js",
-  "module": "index.js",
+  "module": "./package/index.js",
   "types": "types/index.d.ts",
   "files": [
     "index.js",
@@ -43,17 +42,18 @@
     "pub:test": "npm publish package/",
     "sort": "npx sort-package-json",
     "test": "vitest --run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "watch": "svelte-kit package -w"
   },
   "devDependencies": {
-    "@sveltejs/kit": "1.0.0-next.310",
+    "@sveltejs/kit": "1.0.0-next.333",
     "@svelteuidev/tsconfig": "^*",
     "autoprefixer": "10.4.4",
     "cssnano": "5.1.7",
     "jsdom": "19.0.0",
     "postcss": "8.4.12",
     "sass": "1.50.0",
-    "svelte": "3.47.0",
+    "svelte": "3.48.0",
     "svelte-check": "2.5.0",
     "svelte-preprocess": "4.10.5",
     "svelte2tsx": "0.5.7",


### PR DESCRIPTION
* Fix imports in demos (and in other repos) when installing dependencies in the root repo
   * It was related to the fact that the `@svelteuidev` folder content in node_modules was actually a symlink to the packages, so they were not in their transpiled form - not as they appear when they are normally installed as dependencies
   * The fix was defining in each package package.json the `module: ./package/index.js` -> This will require running `npm run package` before starting development - not totally sure if there will be other problems regarding this change :warning: 
* Support for watching packages and having hot reload between packages. If we want to develop, for example, in `demos` but changing the components in `core` and seeing the changes in real time, it can be done now by running `npm run watch` in  the `core` package and `npm run dev` in the `demos` - all changes in core will automatically show in the `demos` development (the same for all repos)
* Bump `svelte` (weird bug where mismatched versions caused problems with svelte:element) and `svelte-kit` (support for `-w` flag for `package`)

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `npm run lint` or just run `npm run repo:prepush` and check to see if it's passing.
