### PR TITLE
[@svelteui/core] Adapt popper position if hidden (on scroll, resize, mount and prop change)

### DIFF
--- a/packages/svelteui-core/src/lib/components/Popper/Popper.styles.ts
+++ b/packages/svelteui-core/src/lib/components/Popper/Popper.styles.ts
@@ -1,7 +1,7 @@
 import type { TransitionConfig, EasingFunction } from 'svelte/transition';
 import type { DefaultProps, Override } from '$lib/styles';
 
-export interface PopperProps extends DefaultProps {
+export interface PopperProps extends DefaultProps<HTMLElement> {
 	position?: 'top' | 'left' | 'bottom' | 'right';
 	placement?: 'start' | 'center' | 'end';
 	gutter?: number;

--- a/packages/svelteui-core/src/lib/components/Popper/Popper.svelte
+++ b/packages/svelteui-core/src/lib/components/Popper/Popper.svelte
@@ -73,6 +73,10 @@
 	function calculatePlacement(reference, element, position, placement, withArrow, arrowSize, arrowDistance, gutter) {
 		if (!reference || !element) return { top: 0, left: 0 };
 		const referenceData = reference.getBoundingClientRect();
+		
+		// take into consideration the page scroll 
+		const referenceTop = referenceData.top + window.scrollY;
+		const referenceBottom = referenceData.bottom + window.scrollY;
 
 		let top = referenceData.bottom;
 		let left = referenceData.x - referenceData.left;
@@ -83,79 +87,79 @@
 		switch(positionPlacement) {
 			case "top-start":
 				left = referenceData.x;
-				top = referenceData.top - element.clientHeight - gutter;
+				top = referenceTop - element.clientHeight - gutter;
 				if (withArrow) top -= arrowSize;
 				arrowTop = element.clientHeight - arrowSize - 1;
 				break;
 			case "top-center":
 				left = referenceData.x + referenceData.width / 2 - element.clientWidth / 2;
-				top = referenceData.top - element.clientHeight - gutter;
+				top = referenceTop - element.clientHeight - gutter;
 				if (withArrow) top -= arrowSize;
 				arrowTop = element.clientHeight - arrowSize - 1;
 				arrowLeft = element.clientWidth / 2 - arrowSize;
 				break;
 			case "top-end":
 				left = referenceData.x + referenceData.width - element.clientWidth;
-				top = referenceData.top - element.clientHeight - gutter;
+				top = referenceTop - element.clientHeight - gutter;
 				if (withArrow) top -= arrowSize;
 				arrowTop = element.clientHeight - arrowSize - 1;
 				arrowLeft = element.clientWidth - arrowSize * 4 - arrowDistance;
 				break;
 			case "bottom-start":
 				left = referenceData.x;
-				top = referenceData.bottom + gutter;
+				top = referenceBottom + gutter;
 				if (withArrow) top += arrowSize;
 				break;
 			case "bottom-center":
 				left = referenceData.x + referenceData.width / 2 - element.clientWidth / 2;
-				top = referenceData.bottom + gutter;
+				top = referenceBottom + gutter;
 				if (withArrow) top += arrowSize;
 				arrowLeft = element.clientWidth / 2 - arrowSize;
 				break;
 			case "bottom-end":
 				left = referenceData.x + referenceData.width - element.clientWidth;
-				top = referenceData.bottom + gutter;
+				top = referenceBottom + gutter;
 				if (withArrow) top += arrowSize;
 				arrowLeft = element.clientWidth - arrowSize * 4 - arrowDistance;
 				break;
 			case "left-start":
 				left = referenceData.x - element.clientWidth - gutter;
-				top = referenceData.top;
+				top = referenceTop;
 				if (withArrow) left -= arrowSize;
 				arrowTop = arrowSize + arrowDistance;
 				arrowLeft = element.clientWidth - arrowSize - 1;
 				break;
 			case "left-center":
 				left = referenceData.x - element.clientWidth - gutter;
-				top = referenceData.bottom - referenceData.height / 2 - element.clientHeight / 2;
+				top = referenceBottom - referenceData.height / 2 - element.clientHeight / 2;
 				if (withArrow) left -= arrowSize;
 				arrowTop = element.clientHeight / 2 - arrowSize;
 				arrowLeft = element.clientWidth - arrowSize - 1;
 				break;
 			case "left-end":
 				left = referenceData.x - element.clientWidth - gutter;
-				top = referenceData.bottom - element.clientHeight;
+				top = referenceBottom - element.clientHeight;
 				if (withArrow) left -= arrowSize;
 				arrowTop = element.clientHeight - arrowSize * 4 - arrowDistance;
 				arrowLeft = element.clientWidth - arrowSize - 1;
 				break;
 			case "right-start":
 				left = referenceData.x + referenceData.width + gutter;
-				top = referenceData.top;
+				top = referenceTop;
 				if (withArrow) left += arrowSize;
 				arrowTop = arrowSize + arrowDistance;
 				arrowLeft = -1 * arrowSize - 1;
 				break;
 			case "right-center":
 				left = referenceData.x + referenceData.width + gutter;
-				top = referenceData.bottom - referenceData.height / 2 - element.clientHeight / 2;
+				top = referenceBottom - referenceData.height / 2 - element.clientHeight / 2;
 				if (withArrow) left += arrowSize;
 				arrowTop = element.clientHeight / 2 - arrowSize;
 				arrowLeft = -1 * arrowSize - 1;
 				break;
 			case "right-end":
 				left = referenceData.x + referenceData.width + gutter;
-				top = referenceData.bottom - element.clientHeight;
+				top = referenceBottom - element.clientHeight;
 				if (withArrow) left += arrowSize;
 				arrowTop = element.clientHeight - arrowSize * 4 - arrowDistance;
 				arrowLeft = -1 * arrowSize - 1;

--- a/packages/svelteui-core/src/lib/components/Popper/Popper.svelte
+++ b/packages/svelteui-core/src/lib/components/Popper/Popper.svelte
@@ -77,88 +77,89 @@
 		// take into consideration the page scroll 
 		const referenceTop = referenceData.top + window.scrollY;
 		const referenceBottom = referenceData.bottom + window.scrollY;
+		const referenceLeft = referenceData.x + window.scrollX;
 
 		let top = referenceData.bottom;
-		let left = referenceData.x - referenceData.left;
+		let left = referenceLeft;
 		let arrowTop = -1 * arrowSize - 1;
 		let arrowLeft = arrowSize + arrowDistance;
 
 		const positionPlacement = `${position}-${placement}`;
 		switch(positionPlacement) {
 			case "top-start":
-				left = referenceData.x;
+				left = referenceLeft;
 				top = referenceTop - element.clientHeight - gutter;
 				if (withArrow) top -= arrowSize;
 				arrowTop = element.clientHeight - arrowSize - 1;
 				break;
 			case "top-center":
-				left = referenceData.x + referenceData.width / 2 - element.clientWidth / 2;
+				left = referenceLeft + referenceData.width / 2 - element.clientWidth / 2;
 				top = referenceTop - element.clientHeight - gutter;
 				if (withArrow) top -= arrowSize;
 				arrowTop = element.clientHeight - arrowSize - 1;
 				arrowLeft = element.clientWidth / 2 - arrowSize;
 				break;
 			case "top-end":
-				left = referenceData.x + referenceData.width - element.clientWidth;
+				left = referenceLeft + referenceData.width - element.clientWidth;
 				top = referenceTop - element.clientHeight - gutter;
 				if (withArrow) top -= arrowSize;
 				arrowTop = element.clientHeight - arrowSize - 1;
 				arrowLeft = element.clientWidth - arrowSize * 4 - arrowDistance;
 				break;
 			case "bottom-start":
-				left = referenceData.x;
+				left = referenceLeft;
 				top = referenceBottom + gutter;
 				if (withArrow) top += arrowSize;
 				break;
 			case "bottom-center":
-				left = referenceData.x + referenceData.width / 2 - element.clientWidth / 2;
+				left = referenceLeft + referenceData.width / 2 - element.clientWidth / 2;
 				top = referenceBottom + gutter;
 				if (withArrow) top += arrowSize;
 				arrowLeft = element.clientWidth / 2 - arrowSize;
 				break;
 			case "bottom-end":
-				left = referenceData.x + referenceData.width - element.clientWidth;
+				left = referenceLeft + referenceData.width - element.clientWidth;
 				top = referenceBottom + gutter;
 				if (withArrow) top += arrowSize;
 				arrowLeft = element.clientWidth - arrowSize * 4 - arrowDistance;
 				break;
 			case "left-start":
-				left = referenceData.x - element.clientWidth - gutter;
+				left = referenceLeft - element.clientWidth - gutter;
 				top = referenceTop;
 				if (withArrow) left -= arrowSize;
 				arrowTop = arrowSize + arrowDistance;
 				arrowLeft = element.clientWidth - arrowSize - 1;
 				break;
 			case "left-center":
-				left = referenceData.x - element.clientWidth - gutter;
+				left = referenceLeft - element.clientWidth - gutter;
 				top = referenceBottom - referenceData.height / 2 - element.clientHeight / 2;
 				if (withArrow) left -= arrowSize;
 				arrowTop = element.clientHeight / 2 - arrowSize;
 				arrowLeft = element.clientWidth - arrowSize - 1;
 				break;
 			case "left-end":
-				left = referenceData.x - element.clientWidth - gutter;
+				left = referenceLeft - element.clientWidth - gutter;
 				top = referenceBottom - element.clientHeight;
 				if (withArrow) left -= arrowSize;
 				arrowTop = element.clientHeight - arrowSize * 4 - arrowDistance;
 				arrowLeft = element.clientWidth - arrowSize - 1;
 				break;
 			case "right-start":
-				left = referenceData.x + referenceData.width + gutter;
+				left = referenceLeft + referenceData.width + gutter;
 				top = referenceTop;
 				if (withArrow) left += arrowSize;
 				arrowTop = arrowSize + arrowDistance;
 				arrowLeft = -1 * arrowSize - 1;
 				break;
 			case "right-center":
-				left = referenceData.x + referenceData.width + gutter;
+				left = referenceLeft + referenceData.width + gutter;
 				top = referenceBottom - referenceData.height / 2 - element.clientHeight / 2;
 				if (withArrow) left += arrowSize;
 				arrowTop = element.clientHeight / 2 - arrowSize;
 				arrowLeft = -1 * arrowSize - 1;
 				break;
 			case "right-end":
-				left = referenceData.x + referenceData.width + gutter;
+				left = referenceLeft + referenceData.width + gutter;
 				top = referenceBottom - element.clientHeight;
 				if (withArrow) left += arrowSize;
 				arrowTop = element.clientHeight - arrowSize * 4 - arrowDistance;


### PR DESCRIPTION
1. Fix popper positioning problem due to scroll.

Reason: `getBoundingClientRect` only returns the positioning of the component taking into consideration the viewport being shown, so it is necessary to add the scroll delta.

https://user-images.githubusercontent.com/25725586/169710166-38d87c9a-194e-4e54-a6a2-7a8fb35dcdd0.mp4

2. Adapt popper positioning if it becomes hidden - on scroll, on resize, on mount and prop change

https://user-images.githubusercontent.com/25725586/169716762-d64f4112-0d87-4606-8945-49db5bc3092b.mp4

https://user-images.githubusercontent.com/25725586/169716763-d38274c5-8ee6-4e8c-ab23-e77700d7a0f6.mp4

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `npm run lint` or just run `npm run repo:prepush` and check to see if it's passing.
