### PR TITLE
[@svelteui/core] Pass tooltip slot element as ref to popper

### DIFF
--- a/packages/svelteui-core/src/lib/components/Tooltip/Tooltip.svelte
+++ b/packages/svelteui-core/src/lib/components/Tooltip/Tooltip.svelte
@@ -87,9 +87,8 @@
 			[`${dark.selector} &`]: {
 				bg: theme.colors[`${color}300`].value
 			},
-			border: 0,
 			background: theme.colors[`${color}900`].value,
-			zIndex: 1
+			zIndex: 0
 		}
 	};
 

--- a/packages/svelteui-core/src/lib/components/Tooltip/Tooltip.svelte
+++ b/packages/svelteui-core/src/lib/components/Tooltip/Tooltip.svelte
@@ -59,12 +59,12 @@
 
 	let openTimeoutRef: number, closeTimeoutRef: number;
 	let _opened = false;
+	let tooltipRefElement = null;
 	let ToolTipStyles: CSS;
 
 	$: visible = (typeof opened === 'boolean' ? opened : _opened) && !disabled;
 
 	$: ToolTipStyles = {
-		position: 'relative',
 		display: 'inline-block',
 
 		'& .body': {
@@ -142,7 +142,6 @@
 	{...$$restProps}
 >
 	<Popper
-		reference={element}
 		{transitionDuration}
 		{position}
 		{placement}
@@ -150,6 +149,7 @@
 		{withArrow}
 		{arrowSize}
 		{zIndex}
+		reference={tooltipRefElement}
 		mounted={visible}
 		arrowDistance={3}
 	>
@@ -165,5 +165,7 @@
 			{label}
 		</Box>
 	</Popper>
-	<slot />
+	<div bind:this={tooltipRefElement}>
+		<slot />
+	</div>
 </Box>


### PR DESCRIPTION
* Pass element reference to popper
* Tweak arrow position in tooltip so that the arrow remains centered vertically (or horizontally if position is left/right)

![image](https://user-images.githubusercontent.com/25725586/170114708-7c122d13-2521-4689-8bba-9857f5c42c61.png)
![image](https://user-images.githubusercontent.com/25725586/170115046-e4ed9579-e49a-4774-a8ed-e2ffade4d28e.png)
![image](https://user-images.githubusercontent.com/25725586/170115063-abc08e3d-9503-4a8b-9ab4-aa2a5dbba01d.png)

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `npm run lint` or just run `npm run repo:prepush` and check to see if it's passing.
