### PR TITLE
[@svelteui/actions] fix failing CI

### DIFF
--- a/packages/svelteui-actions/svelte.config.js
+++ b/packages/svelteui-actions/svelte.config.js
@@ -24,11 +24,13 @@ const config = {
 		},
 		/** @type {import('vite').UserConfig} */
 		vite: {
-			server: {
-				fs: {
-					allow: ['./package']
-				}
-			},
+			server: process.env.VITEST
+				? {}
+				: {
+						fs: {
+							allow: ['./package']
+						}
+				  },
 			test: {
 				globals: true,
 				environment: 'jsdom',


### PR DESCRIPTION
As a kind of :hammer: solution, the server option is not used when running tests - by using the env variable `VITEST` - in the svelte.config.json, which is used by the vitest config.

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `npm run lint` or just run `npm run repo:prepush` and check to see if it's passing.
