### PR TITLE
[@svelteui/core] Text input

### DIFF
--- a/packages/svelteui-core/src/lib/components/Input/Input.styles.ts
+++ b/packages/svelteui-core/src/lib/components/Input/Input.styles.ts
@@ -5,10 +5,10 @@ export interface InputBaseProps extends DefaultProps {
 	icon: Component | HTMLOrSVGElement;
 	iconWidth: number;
 	iconProps: { size: number; color: 'currentColor' | string };
-	rightSection: Component | HTMLOrSVGElement;
 	rightSectionWidth: number;
 	rightSectionProps: Record<string, unknown>;
 	wrapperProps: Record<string, unknown>;
+	id: string;
 	required: boolean;
 	radius: SvelteUINumberSize;
 	variant: InputVariant;

--- a/packages/svelteui-core/src/lib/components/Input/Input.styles.ts
+++ b/packages/svelteui-core/src/lib/components/Input/Input.styles.ts
@@ -5,6 +5,7 @@ export interface InputBaseProps extends DefaultProps {
 	icon: Component | HTMLOrSVGElement;
 	iconWidth: number;
 	iconProps: { size: number; color: 'currentColor' | string };
+	showRightSection: boolean;
 	rightSectionWidth: number;
 	rightSectionProps: Record<string, unknown>;
 	wrapperProps: Record<string, unknown>;

--- a/packages/svelteui-core/src/lib/components/Input/Input.svelte
+++ b/packages/svelteui-core/src/lib/components/Input/Input.svelte
@@ -24,6 +24,8 @@
 	export let iconWidth: $$InputProps['iconWidth'] = 36;
 	/** Props spread to icon component */
 	export let iconProps: $$InputProps['iconProps'] = { size: 20, color: 'currentColor' };
+	/** Determines if the right section is shown, defaults to true if the slot is provided */
+	export let showRightSection: $$InputProps['showRightSection'] = $$slots.rightSection;
 	/** Width of right section, is used to calculate input padding-right */
 	export let rightSectionWidth: $$InputProps['rightSectionWidth'] = 36;
 	/** Props spread to rightSection div element */
@@ -54,7 +56,6 @@
 
 	let isHTMLElement;
 	let isComponent;
-	const withRightSection = $$slots.rightSection;
 	$: {
 		isHTMLElement = root && typeof root === 'string';
 		isComponent = root && typeof root === 'function';
@@ -105,7 +106,7 @@
 								: 12,
 						paddingRight:
 							variant === 'default' || variant === 'filled'
-								? withRightSection
+								? showRightSection
 									? rightSectionWidth
 									: null
 								: null,
@@ -353,7 +354,7 @@ Base component to create custom inputs
 			<slot />
 		</svelte:component>
 	{/if}
-	{#if withRightSection}
+	{#if showRightSection}
 		<div {...rightSectionProps} class="rightSection">
 			<slot name="rightSection" />
 		</div>

--- a/packages/svelteui-core/src/lib/components/Input/Input.svelte
+++ b/packages/svelteui-core/src/lib/components/Input/Input.svelte
@@ -24,14 +24,14 @@
 	export let iconWidth: $$InputProps['iconWidth'] = 36;
 	/** Props spread to icon component */
 	export let iconProps: $$InputProps['iconProps'] = { size: 20, color: 'currentColor' };
-	/** Right section of input, similar to icon but on the right */
-	export let rightSection: $$InputProps['rightSection'] = null;
 	/** Width of right section, is used to calculate input padding-right */
 	export let rightSectionWidth: $$InputProps['rightSectionWidth'] = 36;
 	/** Props spread to rightSection div element */
 	export let rightSectionProps: $$InputProps['rightSectionProps'] = {};
 	/** Properties spread to root element */
 	export let wrapperProps: $$InputProps['wrapperProps'] = {};
+	/** Id of the component to be linked to a label */
+	export let id: $$InputProps['id'] = 'input-id';
 	/** Sets required on input element */
 	export let required: $$InputProps['required'] = false;
 	/** Input border-radius from theme or number to set border-radius in px */
@@ -54,7 +54,7 @@
 
 	let isHTMLElement;
 	let isComponent;
-	const withRightSection = !!rightSection;
+	const withRightSection = $$slots.rightSection;
 	$: {
 		isHTMLElement = root && typeof root === 'string';
 		isComponent = root && typeof root === 'function';
@@ -308,6 +308,7 @@ Base component to create custom inputs
 			use:forwardEvents
 			{required}
 			{disabled}
+			{id}
 			aria-invalid={invalid}
 			class:disabled
 			class:invalid
@@ -325,6 +326,7 @@ Base component to create custom inputs
 			on:change={onChange}
 			{required}
 			{disabled}
+			{id}
 			aria-invalid={invalid}
 			class:disabled
 			class:invalid
@@ -344,13 +346,14 @@ Base component to create custom inputs
 				: null} {icon ? 'withIcon' : null}"
 			{disabled}
 			{required}
+			{id}
 			aria-invalid={invalid}
 			{...$$restProps}
 		>
 			<slot />
 		</svelte:component>
 	{/if}
-	{#if $$slots.rightSection}
+	{#if withRightSection}
 		<div {...rightSectionProps} class="rightSection">
 			<slot name="rightSection" />
 		</div>

--- a/packages/svelteui-core/src/lib/components/NumberInput/NumberInput.styles.ts
+++ b/packages/svelteui-core/src/lib/components/NumberInput/NumberInput.styles.ts
@@ -1,6 +1,6 @@
-import type { InputBaseProps } from '../Input/Input.styles';
+import type { TextInputProps } from '../TextInput/TextInput.styles';
 
-export interface NumberInputProps extends InputBaseProps {
+export interface NumberInputProps extends Omit<TextInputProps, 'value'> {
 	value?: number | undefined;
 	defaultValue?: number | undefined;
 	invalid?: boolean;

--- a/packages/svelteui-core/src/lib/components/NumberInput/NumberInput.styles.ts
+++ b/packages/svelteui-core/src/lib/components/NumberInput/NumberInput.styles.ts
@@ -1,8 +1,8 @@
 import type { TextInputProps } from '../TextInput/TextInput.styles';
 
 export interface NumberInputProps extends Omit<TextInputProps, 'value'> {
-	value?: number | undefined;
-	defaultValue?: number | undefined;
+	value?: number;
+	defaultValue?: number;
 	invalid?: boolean;
 	decimalSeparator?: string;
 	max?: number;

--- a/packages/svelteui-core/src/lib/components/NumberInput/NumberInput.svelte
+++ b/packages/svelteui-core/src/lib/components/NumberInput/NumberInput.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { createEventDispatcher } from 'svelte';
 	import { css, dark } from '$lib/styles';
-	import TextInput from '../TextInput/TextInput.svelte';
+	import { TextInput } from '../TextInput';
 	import { CONTROL_SIZES, defaultFormatter, defaultParser } from './NumberInput.styles';
 	import type { NumberInputProps as $$NumberInputProps } from './NumberInput.styles';
 

--- a/packages/svelteui-core/src/lib/components/NumberInput/NumberInput.svelte
+++ b/packages/svelteui-core/src/lib/components/NumberInput/NumberInput.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { createEventDispatcher } from 'svelte';
 	import { css, dark } from '$lib/styles';
-	import Input from '../Input/Input.svelte';
+	import TextInput from '../TextInput/TextInput.svelte';
 	import { CONTROL_SIZES, defaultFormatter, defaultParser } from './NumberInput.styles';
 	import type { NumberInputProps as $$NumberInputProps } from './NumberInput.styles';
 
@@ -273,10 +273,11 @@ values and add custom parsers and formatters.
     <NumberInput defaultValue={2} />
 	<NumberInput max={10} min={0} step={0.5} precision={1} />
 	<NumberInput defaultValue={0} step={0.2} precision={2} decimalSeparator="," />
+	<NumberInput label='Your age' required defaultValue={0} />
     ```
 -->
 
-<Input
+<TextInput
 	{use}
 	{root}
 	{icon}
@@ -291,6 +292,7 @@ values and add custom parsers and formatters.
 	class="{className}"
 	override={{ ...override, '& .rightSection': { width: 'auto' } }}
 	value={formatNumber(value)}
+	{...$$restProps}
 	bind:element={element}
 	on:input={onInput}
 	on:keyup={onKeyUp}
@@ -321,4 +323,4 @@ values and add custom parsers and formatters.
 			/>
 		{/if}
 	</div>
-</Input>
+</TextInput>

--- a/packages/svelteui-core/src/lib/components/TextInput/TextInput.styles.ts
+++ b/packages/svelteui-core/src/lib/components/TextInput/TextInput.styles.ts
@@ -1,0 +1,7 @@
+import type { Override } from '$lib/styles';
+import type { InputProps } from '../Input/Input.styles';
+import type { InputWrapperProps } from '../InputWrapper/InputWrapper.styles';
+
+export interface TextInputProps extends InputProps, InputWrapperProps {
+	overrideInput?: Override['props'];
+}

--- a/packages/svelteui-core/src/lib/components/TextInput/TextInput.svelte
+++ b/packages/svelteui-core/src/lib/components/TextInput/TextInput.svelte
@@ -17,7 +17,7 @@
 	/** Css prop for custom theming the component */
 	export let overrideInput: $$TextInputProps['overrideInput'] = {};
 	/** Input label, displayed before input */
-	export let label: $$TextInputProps['label'] = 'label';
+	export let label: $$TextInputProps['label'] = '';
 	/** Input description, displayed after label */
 	export let description: $$TextInputProps['description'] = null;
 	/** Displays error message after input */

--- a/packages/svelteui-core/src/lib/components/TextInput/TextInput.svelte
+++ b/packages/svelteui-core/src/lib/components/TextInput/TextInput.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import { createEventForwarder, useActions } from '$lib/internal';
 	import { get_current_component } from 'svelte/internal';
-	import InputWrapper from '../InputWrapper/InputWrapper.svelte';
-	import Input from '../Input/Input.svelte';
+	import { InputWrapper } from '../InputWrapper';
+	import { Input } from '../Input';
 	import type { TextInputProps as $$TextInputProps } from './TextInput.styles';
 
 	/** Used for forwarding actions from component */

--- a/packages/svelteui-core/src/lib/components/TextInput/TextInput.svelte
+++ b/packages/svelteui-core/src/lib/components/TextInput/TextInput.svelte
@@ -40,7 +40,9 @@
 	/** An action that forwards inner dom node events from parent component */
 	const forwardEvents = createEventForwarder(get_current_component());
 
-	const withRightSection = $$slots.rightSection;
+    // Flag that enables the override of the right section slot
+    // of the Input component only if it was provided
+	const showRightSection = !!$$slots.rightSection;
 </script>
 
 <!--
@@ -86,13 +88,10 @@ Input for text that also uses labels for the input
 		{overrideInput}
 		{required}
 		{size}
-        {id}
+		{id}
+        {showRightSection}
 		{...$$restProps}
 	>
-		<div slot="rightSection">
-			{#if withRightSection}
-				<slot name="rightSection" />
-			{/if}
-		</div>
+        <slot slot='rightSection' name='rightSection'></slot>
 	</Input>
 </InputWrapper>

--- a/packages/svelteui-core/src/lib/components/TextInput/TextInput.svelte
+++ b/packages/svelteui-core/src/lib/components/TextInput/TextInput.svelte
@@ -1,0 +1,98 @@
+<script lang="ts">
+	import { createEventForwarder, useActions } from '$lib/internal';
+	import { get_current_component } from 'svelte/internal';
+	import InputWrapper from '../InputWrapper/InputWrapper.svelte';
+	import Input from '../Input/Input.svelte';
+	import type { TextInputProps as $$TextInputProps } from './TextInput.styles';
+
+	/** Used for forwarding actions from component */
+	export let use: $$TextInputProps['use'] = [];
+	/** Used for components to bind to elements */
+	export let element: $$TextInputProps['element'] = undefined;
+	/** Used for custom classes to be applied to the text e.g. Tailwind classes */
+	export let className: $$TextInputProps['className'] = '';
+	export { className as class };
+	/** Css prop for custom theming the component */
+	export let override: $$TextInputProps['override'] = {};
+	/** Css prop for custom theming the component */
+	export let overrideInput: $$TextInputProps['overrideInput'] = {};
+	/** Input label, displayed before input */
+	export let label: $$TextInputProps['label'] = 'label';
+	/** Input description, displayed after label */
+	export let description: $$TextInputProps['description'] = null;
+	/** Displays error message after input */
+	export let error: $$TextInputProps['error'] = null;
+	/** Adds red asterisk on the right side of label */
+	export let required: $$TextInputProps['required'] = false;
+	/** Props spread to label element */
+	export let labelProps: $$TextInputProps['labelProps'] = {};
+	/** Props spread to description element */
+	export let descriptionProps: $$TextInputProps['descriptionProps'] = {};
+	/** Props spread to error element */
+	export let errorProps: $$TextInputProps['errorProps'] = {};
+	/** htmlFor label prop */
+	export let id: $$TextInputProps['id'] = 'input-id';
+	/** Render label as label with htmlFor or as div */
+	export let labelElement: $$TextInputProps['labelElement'] = 'label';
+	/** Controls all elements font-size */
+	export let size: $$TextInputProps['size'] = 'sm';
+
+	/** An action that forwards inner dom node events from parent component */
+	const forwardEvents = createEventForwarder(get_current_component());
+
+	const withRightSection = $$slots.rightSection;
+</script>
+
+<!--
+@component
+
+Input for text that also uses labels for the input
+	
+@see https://svelteui.org/core/text
+@example
+    ```tsx
+    <TextInput 
+        placeholder='Your name'
+        description="Don't forget to add your full name"
+        label='Full name'
+        required
+    />
+    <TextInput 
+        placeholder='Your name'
+        label='Full name'
+        size='lg'
+        on:change={onChange}
+    />
+    ```
+-->
+
+<InputWrapper
+	class={className}
+	{override}
+	{label}
+	{description}
+	{error}
+	{required}
+	{labelProps}
+	{descriptionProps}
+	{errorProps}
+	{id}
+	{labelElement}
+	{size}
+	bind:element
+>
+	<Input
+		use={[forwardEvents, [useActions, use]]}
+		{overrideInput}
+		{required}
+		{size}
+        {id}
+		{...$$restProps}
+	>
+		<div slot="rightSection">
+			{#if withRightSection}
+				<slot name="rightSection" />
+			{/if}
+		</div>
+	</Input>
+</InputWrapper>

--- a/packages/svelteui-core/src/lib/components/TextInput/index.ts
+++ b/packages/svelteui-core/src/lib/components/TextInput/index.ts
@@ -1,0 +1,2 @@
+export { default as TextInput } from './TextInput.svelte';
+export * as TextInputStyles from './TextInput.styles';

--- a/packages/svelteui-core/src/lib/components/index.ts
+++ b/packages/svelteui-core/src/lib/components/index.ts
@@ -33,6 +33,7 @@ export * from './Space';
 export * from './Stack';
 export * from './Switch';
 export * from './Text';
+export * from './TextInput';
 export * from './ThemeIcon';
 export * from './Title';
 export * from './Tooltip';

--- a/packages/svelteui-core/src/routes/index.svelte
+++ b/packages/svelteui-core/src/routes/index.svelte
@@ -29,6 +29,7 @@
 		Overlay,
 		SimpleGrid,
 		Container,
+		TextInput,
 		Tooltip,
 		Kbd,
 		Paper,


### PR DESCRIPTION
### Text input component

* uses `InputWrapper` and `Input` components
* Workaround made for propagating the slot `rightSection`, which should not "appear" if the users of `TextInput` do not use it - this was made with the prop `showRightSection` in the `Input` which contains by default the previous behaviour.
* Modified `NumberInput` to use `TextInput` as base

![image](https://user-images.githubusercontent.com/25725586/170862767-72e36d03-64a4-47b9-86d3-8cdc869c79e3.png)

```svelte
<TextInput 
	placeholder='Your name'
	description="Don't forget to add your full name"
	label='Full name'
	required
/>
<TextInput 
	placeholder='Your name'
	label='Full name'
	size='lg'
	on:input={() => { console.log(this.value) }}
/>
<TextInput
	label="E-mail"
	invalid
	error="Invalid email"
	rightSection={true}
	rightSectionWidth={70}
>
	<div slot='rightSection'>
		<Text>@</Text>
	</div>
</TextInput>
```

![image](https://user-images.githubusercontent.com/25725586/170863056-41beb23c-0687-46d6-a101-6d5e72bfbcc2.png)

```svelte
<NumberInput
	label="Your age"
	min={0}
	required
/>
```

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `npm run lint` or just run `npm run repo:prepush` and check to see if it's passing.
