### PR TITLE
[@svelteui/core]: fix number input inconsistencies

### DIFF
--- a/packages/svelteui-core/src/lib/components/NumberInput/NumberInput.svelte
+++ b/packages/svelteui-core/src/lib/components/NumberInput/NumberInput.svelte
@@ -106,10 +106,9 @@
 		} else {
 			const parsedNumber = parseNumber(this.value);
 			if (parsedNumber === undefined || Number.isNaN(parseNumber)) return;
-
-			const clamped = Math.min(Math.max(parseFloat(parsedNumber), min), max);
-			value = parseFloat(clamped.toFixed(precision));
+			value = parseFloat(parsedNumber);
 		}
+		dispatch('change', value);
 	}
 
 	function stepInterval(up) {
@@ -125,9 +124,9 @@
 	function onStep(up, hold = true, first = true) {
 		const _value = value === undefined ? 0 : value
 		const tmpValue = up ? _value + step : _value - step;
-		const clamp = Math.min(Math.max(tmpValue, min), max);
 
-		value = parseFloat(clamp.toFixed(precision));
+		const clamped = _clamp(tmpValue);
+		value = parseFloat(clamped.toFixed(precision));
 		stepCount += 1;
 
 		// dispatches change events so that listeners can get
@@ -168,7 +167,16 @@
 
 	function onBlur() {
 		if (noClampOnBlur) return;
+
+		const clamped = _clamp(value);
+		value = parseFloat(clamped.toFixed(precision));;
+		dispatch('change', value);
+
 		(element as HTMLInputElement).value = formatNumber(value);
+	}
+
+	function _clamp(value) {
+		return Math.min(Math.max(value, min), max); 
 	}
 
 	function _valueC(val: number): number | undefined {


### PR DESCRIPTION
Fixed problems with Number Input mentioned in https://github.com/svelteuidev/svelteui/pull/86#issue-1253046186

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `npm run lint` or just run `npm run repo:prepush` and check to see if it's passing.
