### PR TITLE
[core] Pre release script for tsconfig changes

### DIFF
--- a/scripts/pre-release.ts
+++ b/scripts/pre-release.ts
@@ -1,13 +1,33 @@
 import { expandGlob } from 'https://deno.land/std@0.95.0/fs/mod.ts';
 
 async function preparePackages() {
-	for await (const file of expandGlob(`./packages/**/package/package.json`)) {
+	for await (const file of expandGlob(`./packages/**/package.json`)) {
 		const json = JSON.parse(await Deno.readTextFile(file.path));
 
+		// change module of package.json to point to the index.js
+		// that will be created with the 'package' command
 		json.module = 'index.js';
 
 		await Deno.writeTextFile(file.path, JSON.stringify(json, null, '\t'));
 	}
 }
 
-await preparePackages();
+async function prepareTSConfig() {
+	for await (const file of expandGlob(`./packages/*/tsconfig.json`)) {
+		const json = JSON.parse(await Deno.readTextFile(file.path));
+		
+		// remove all mentions of other packages inside tsconfig.json files
+		for (const key of Object.keys(json.compilerOptions.paths)) {
+			if (!key.startsWith("@svelteuidev")) continue;
+			delete json.compilerOptions.paths[key]
+		}
+		json.references = [];
+
+		await Deno.writeTextFile(file.path, JSON.stringify(json, null, '\t'));
+	}
+}
+
+await Promise.all([
+	preparePackages(),
+	prepareTSConfig()
+]);


### PR DESCRIPTION
Added to the `pre-release` script a new step that removes mentions of "local" packages, to be run before the publishing of the packages.

Also a small fix to the `preparePackages` function, which should be changing on the package.json of the sub package and not on the generated one.

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `npm run lint` or just run `npm run repo:prepush` and check to see if it's passing.
