### PR TITLE
[docs] Paper and anchor docs

### DIFF
--- a/docs/src/includes/sidebar.md
+++ b/docs/src/includes/sidebar.md
@@ -60,6 +60,7 @@
   - [Box](core/box)
   - [BrowserRender](core/browser-render)
   - [Divider](core/divider)
+  - [Paper](core/paper)
   - [ServerRender](core/server-render)
   - [Fragment](core/fragment)
 - ### SvelteUI Actions

--- a/docs/src/includes/sidebar.md
+++ b/docs/src/includes/sidebar.md
@@ -2,7 +2,7 @@
   import { MainLink } from "components";
   import { Space } from "@svelteuidev/core";
   import { Layout, Input, Stack, Dashboard, LetterCaseToggle, ExclamationTriangle, BoxModel } from "radix-icons-svelte";
-	import { StarFilled, QuestionMarkCircled, GithubLogo, Cube, Download } from 'radix-icons-svelte';
+	import { Cube, Download, GithubLogo, HamburgerMenu, QuestionMarkCircled, StarFilled } from 'radix-icons-svelte';
 </script>
 
 - <MainLink href='introduction'><Cube slot='icon' size={20} />Introduction</MainLink>
@@ -42,6 +42,8 @@
   - [NativeSelect](core/native-select)
   - [NumberInput](core/number-input)
   - [Switch](core/switch)
+  - **<HamburgerMenu/><Space />Navigation**
+  - [Anchor](core/anchor)
   - **<Dashboard/><Space />Data Display**
   - [Badge](core/badge)
   - [Image](core/image)

--- a/docs/src/pages/core/anchor.md
+++ b/docs/src/pages/core/anchor.md
@@ -40,6 +40,13 @@ Anchor is a wrapper around the [Text](core/text.md) component that uses `a` as t
 
 To use Anchor with svelte-routing `Link` component and other similar components set `root` prop:
 
-<Box css={{pre: {bc: '$gray50'}, 'pre code': {color: '$gray900'}}}>
-    <Prism language='svelte' code={routing} />
-</Box>
+```svelte
+<script>
+    import { Link } from "svelte-routing";
+    import { Anchor } from '@svelteuidev/core';
+</script>
+
+<Anchor root={Link} to="/">
+    Svelte router link
+</Anchor>
+```

--- a/docs/src/pages/core/anchor.md
+++ b/docs/src/pages/core/anchor.md
@@ -22,7 +22,7 @@ docs: 'core/anchor.md'
     import { Anchor } from '@svelteuidev/core';
 <\/script>
 
-<Anchor component={Link} to="/">
+<Anchor root={Link} to="/">
     Svelte router link
 <\/Anchor>
     `;
@@ -37,6 +37,8 @@ Anchor is a wrapper around the [Text](core/text.md) component that uses `a` as t
 <Demo demo={AnchorDemos.usage} />
 
 ## Usage with svelte-routing and other libraries
+
+To use Anchor with svelte-routing `Link` component and other similar components set `root` prop:
 
 <Box css={{pre: {bc: '$gray50'}, 'pre code': {color: '$gray900'}}}>
     <Prism language='svelte' code={routing} />

--- a/docs/src/pages/core/anchor.md
+++ b/docs/src/pages/core/anchor.md
@@ -1,0 +1,43 @@
+---
+title: Anchor
+group: 'svelteuidev-core'
+packageGroup: '@svelteuidev/core'
+slug: /core/anchor/
+category: 'navigation'
+description: 'Display links with theme styles'
+import: "import { Anchor } from '@svelteuidev/core';"
+source: 'svelte-core/src/lib/components/Anchor/Anchor.svelte'
+docs: 'core/anchor.md'
+---
+
+<script>
+    import { Demo, AnchorDemos } from '@svelteuidev/demos';
+    import { Prism } from '@svelteuidev/prism';
+    import { Box } from '@svelteuidev/core';
+    import { Heading } from 'components';
+
+    const routing = `
+<script>
+    import { Link } from "svelte-routing";
+    import { Anchor } from '@svelteuidev/core';
+<\/script>
+
+<Anchor component={Link} to="/">
+    Svelte router link
+<\/Anchor>
+    `;
+</script>
+
+<Heading />
+
+## Usage
+
+Anchor is a wrapper around the [Text](core/text.md) component that uses `a` as the root of the element. It supports the same props as the `Text` component.
+
+<Demo demo={AnchorDemos.usage} />
+
+## Usage with svelte-routing and other libraries
+
+<Box css={{pre: {bc: '$gray50'}, 'pre code': {color: '$gray900'}}}>
+    <Prism language='svelte' code={routing} />
+</Box>

--- a/docs/src/pages/core/anchor.md
+++ b/docs/src/pages/core/anchor.md
@@ -13,17 +13,6 @@ docs: 'core/anchor.md'
 <script>
     import { Demo, AnchorDemos } from '@svelteuidev/demos';
     import { Heading } from 'components';
-
-    const routing = `
-<script>
-    import { Link } from "svelte-routing";
-    import { Anchor } from '@svelteuidev/core';
-<\/script>
-
-<Anchor root={Link} to="/">
-    Svelte router link
-<\/Anchor>
-    `;
 </script>
 
 <Heading />
@@ -33,18 +22,3 @@ docs: 'core/anchor.md'
 Anchor is a wrapper around the [Text](core/text.md) component that uses `a` as the root of the element. It supports the same props as the `Text` component.
 
 <Demo demo={AnchorDemos.usage} />
-
-## Usage with svelte-routing and other libraries
-
-To use Anchor with svelte-routing `Link` component and other similar components set `root` prop:
-
-```svelte
-<script>
-    import { Link } from "svelte-routing";
-    import { Anchor } from '@svelteuidev/core';
-</script>
-
-<Anchor root={Link} to="/">
-    Svelte router link
-</Anchor>
-```

--- a/docs/src/pages/core/anchor.md
+++ b/docs/src/pages/core/anchor.md
@@ -12,8 +12,6 @@ docs: 'core/anchor.md'
 
 <script>
     import { Demo, AnchorDemos } from '@svelteuidev/demos';
-    import { Prism } from '@svelteuidev/prism';
-    import { Box } from '@svelteuidev/core';
     import { Heading } from 'components';
 
     const routing = `

--- a/docs/src/pages/core/number-input.md
+++ b/docs/src/pages/core/number-input.md
@@ -11,10 +11,8 @@ docs: 'core/number-input.md'
 ---
 
 <script>
-    import { Box } from '@svelteuidev/core';
-    import { Prism } from '@svelteuidev/prism';
     import { Demo, NumberInputDemos } from '@svelteuidev/demos';
-    import { CodeBlock, Heading, Preview } from 'components';
+    import { CodeBlock, Heading } from 'components';
 </script>
 
 <style global>

--- a/docs/src/pages/core/number-input.md
+++ b/docs/src/pages/core/number-input.md
@@ -15,32 +15,6 @@ docs: 'core/number-input.md'
     import { Prism } from '@svelteuidev/prism';
     import { Demo, NumberInputDemos } from '@svelteuidev/demos';
     import { CodeBlock, Heading, Preview } from 'components';
-
-    const controlled = `
-    <script>
-        import { NumberInput } from '@svelteuidev/core';
-
-        let value;
-        function onChange(e) {
-            value = e.detail;
-        }
-    <\/script>
-
-    <NumberInput value={value} on:change={onChange} \/>
-    `;
-
-    const blur = `<NumberInput noClampOnBlur \/>`;
-
-    const accessibility = `
-    <NumberInput /> // -> not ok, input is not labeled
-    <NumberInput label="Your age" /> // -> ok, input and label are connected
-    <NumberInput aria-label="Your age" /> // -> ok, label is not visible but will be announced by screen reader
-    `;
-
-    let value;
-    function onChange(e) {
-        value = e.detail;
-    }
 </script>
 
 <style global>
@@ -57,17 +31,26 @@ docs: 'core/number-input.md'
 
 ## Controlled
 
-<Box css={{ pre: { bc: '$gray50' }, 'pre code': { color: '$gray900' } }}>
-    <Prism language='svelte' code={controlled} />
-</Box>
+```svelte
+<script>
+    import { NumberInput } from '@svelteuidev/core';
+
+    let value;
+    function onChange(e) {
+        value = e.detail;
+    }
+</script>
+
+<NumberInput value={value} on:change={onChange} />
+```
 
 ## Clamp on blur
 
 NumberInput has an internal state to control the value of the user input. When the blur event is triggered, it clamps the value with the given min and max values and removes invalid values, for example text.
 
-<Box css={{ pre: { bc: '$gray50' }, 'pre code': { color: '$gray900' } }}>
-    <Prism language='svelte' code={blur} />
-</Box>
+```svelte
+<NumberInput noClampOnBlur />
+```
 
 ## Parser and formatter
 
@@ -132,6 +115,8 @@ NumberInput renders regular input with `type="text"`. Increment/decrement contro
 
 Provide `aria-label` in case you use component without label for screen reader support:
 
-<Box css={{ pre: { bc: '$gray50' }, 'pre code': { color: '$gray900' } }}>
-    <Prism language='svelte' code={accessibility} />
-</Box>
+```svelte
+<NumberInput /> // -> not ok, input is not labeled
+<NumberInput label="Your age" /> // -> ok, input and label are connected
+<NumberInput aria-label="Your age" /> // -> ok, label is not visible but will be announced by screen reader
+```

--- a/docs/src/pages/core/paper.md
+++ b/docs/src/pages/core/paper.md
@@ -1,0 +1,60 @@
+---
+title: Paper
+group: 'svelteuidev-core'
+packageGroup: '@svelteuidev/core'
+slug: /core/paper/
+category: 'misc'
+description: 'Renders white or dark containers depending on color scheme'
+import: "import { Paper } from '@svelteuidev/core';"
+source: 'svelte-core/src/lib/components/Paper/Paper.svelte'
+docs: 'core/paper.md'
+---
+
+<script>
+    import { Demo, PaperDemos } from '@svelteuidev/demos';
+    import { Prism } from '@svelteuidev/prism';
+    import { Box } from '@svelteuidev/core';
+    import { Heading } from 'components';
+
+    const shadows = `
+<script>
+    import { Paper } from '@svelteuidev/core';
+<\/script>
+
+<Paper shadow="xs" \/>
+<Paper shadow="13px 18px 25px #e5e5e5, 1px 3px 3px #e5e5e5, -1px 3px 3px #e5e5e5" \/>
+    `;
+
+    const radius = `
+<script>
+    import { Paper } from '@svelteuidev/core';
+<\/script>
+
+<Paper radius="lg" \/>
+<Paper radius={10} \/>
+    `;
+</script>
+
+<Heading />
+
+## Usage
+
+Paper component renders white or dark background with shadow, border-radius and border from theme.
+
+<Demo demo={PaperDemos.configurator} />
+
+## Shadow
+
+You can use the predefined shadows from the [theme](theming/default-theme#shadows) or you own:
+
+<Box css={{pre: {bc: '$gray50'}, 'pre code': {color: '$gray900'}}}>
+    <Prism language='svelte' code={shadows} />
+</Box>
+
+## Radius
+
+You can use the predefined radius value from the [theme](theming/default-theme#radius) or use a number value that will be set to px:
+
+<Box css={{pre: {bc: '$gray50'}, 'pre code': {color: '$gray900'}}}>
+    <Prism language='svelte' code={radius} />
+</Box>

--- a/docs/src/pages/core/paper.md
+++ b/docs/src/pages/core/paper.md
@@ -12,8 +12,6 @@ docs: 'core/paper.md'
 
 <script>
     import { Demo, PaperDemos } from '@svelteuidev/demos';
-    import { Prism } from '@svelteuidev/prism';
-    import { Box } from '@svelteuidev/core';
     import { Heading } from 'components';
 </script>
 

--- a/docs/src/pages/core/paper.md
+++ b/docs/src/pages/core/paper.md
@@ -15,24 +15,6 @@ docs: 'core/paper.md'
     import { Prism } from '@svelteuidev/prism';
     import { Box } from '@svelteuidev/core';
     import { Heading } from 'components';
-
-    const shadows = `
-<script>
-    import { Paper } from '@svelteuidev/core';
-<\/script>
-
-<Paper shadow="xs" \/>
-<Paper shadow="13px 18px 25px #e5e5e5, 1px 3px 3px #e5e5e5, -1px 3px 3px #e5e5e5" \/>
-    `;
-
-    const radius = `
-<script>
-    import { Paper } from '@svelteuidev/core';
-<\/script>
-
-<Paper radius="lg" \/>
-<Paper radius={10} \/>
-    `;
 </script>
 
 <Heading />
@@ -47,14 +29,24 @@ Paper component renders white or dark background with shadow, border-radius and 
 
 You can use the predefined shadows from the [theme](theming/default-theme#shadows) or you own:
 
-<Box css={{pre: {bc: '$gray50'}, 'pre code': {color: '$gray900'}}}>
-    <Prism language='svelte' code={shadows} />
-</Box>
+```svelte
+<script>
+    import { Paper } from '@svelteuidev/core';
+</script>
+
+<Paper shadow="xs" />
+<Paper shadow="13px 18px 25px #e5e5e5, 1px 3px 3px #e5e5e5, -1px 3px 3px #e5e5e5" />
+```
 
 ## Radius
 
 You can use the predefined radius value from the [theme](theming/default-theme#radius) or use a number value that will be set to px:
 
-<Box css={{pre: {bc: '$gray50'}, 'pre code': {color: '$gray900'}}}>
-    <Prism language='svelte' code={radius} />
-</Box>
+```svelte
+<script>
+    import { Paper } from '@svelteuidev/core';
+</script>
+
+<Paper radius="lg" />
+<Paper radius={10} />
+```

--- a/packages/svelteui-demos/src/lib/demos/core/Anchor/Anchor.demo.usage.svelte
+++ b/packages/svelteui-demos/src/lib/demos/core/Anchor/Anchor.demo.usage.svelte
@@ -1,0 +1,23 @@
+<script lang="ts" context="module">
+	import type { CodeDemoType, CodeDemoConfiguration } from '$lib/types';
+
+	const code = `
+<script>
+    import { Anchor } from '@svelteuidev/core';
+<\/script>
+
+<Anchor>SvelteUI documentation</Anchor>
+	`;
+
+	export const type: CodeDemoType['type'] = 'demo';
+
+	export const configuration: CodeDemoConfiguration = {
+		code
+	};
+</script>
+
+<script lang="ts">
+	import { Anchor } from '@svelteuidev/core';
+</script>
+
+<Anchor>SvelteUI documentation</Anchor>

--- a/packages/svelteui-demos/src/lib/demos/core/Anchor/index.ts
+++ b/packages/svelteui-demos/src/lib/demos/core/Anchor/index.ts
@@ -1,0 +1,1 @@
+export * as usage from './Anchor.demo.usage.svelte';

--- a/packages/svelteui-demos/src/lib/demos/core/Paper/Paper.demo.configurator.svelte
+++ b/packages/svelteui-demos/src/lib/demos/core/Paper/Paper.demo.configurator.svelte
@@ -1,0 +1,40 @@
+<script lang="ts" context="module">
+	import type { ConfiguratorDemoType, ConfiguratorDemoConfiguration } from '$lib/types';
+
+	const codeTemplate = (props: string, children: string) => `
+<script>
+  import { Paper } from '@svelteuidev/core';
+<\/script>
+
+<Paper${props}>
+  ${children}
+</Paper>
+`;
+
+    const children = `Paper is the most basic UI component. Use it to create cards, dropdowns, modals and other components that require background with shadow`;
+
+	export const type: ConfiguratorDemoType['type'] = 'configurator';
+
+	export const configuration: ConfiguratorDemoConfiguration = {
+		codeTemplate,
+		configurator: [
+			{ name: 'shadow', type: 'size', initialValue: 'xs', defaultValue: 'xs' },
+			{ name: 'radius', type: 'size', initialValue: 'sm', defaultValue: 'sm' },
+			{ name: 'withBorder', label: 'With Border', type: 'boolean', initialValue: false, defaultValue: false },
+            { name: 'children', type: 'string', initialValue: children }
+		]
+	};
+</script>
+
+<script lang="ts">
+	import type { PaperStyles } from '@svelteuidev/core';
+	import { Paper, Center } from '@svelteuidev/core';
+
+	export let props: PaperStyles.PaperProps = {};
+</script>
+
+<Center override={{ width: 400, height: 200, m: 'auto' }}>
+	<Paper {...props}>
+        <slot />
+    </Paper>
+</Center>

--- a/packages/svelteui-demos/src/lib/demos/core/Paper/index.ts
+++ b/packages/svelteui-demos/src/lib/demos/core/Paper/index.ts
@@ -1,0 +1,1 @@
+export * as configurator from './Paper.demo.configurator.svelte';

--- a/packages/svelteui-demos/src/lib/index.ts
+++ b/packages/svelteui-demos/src/lib/index.ts
@@ -12,6 +12,7 @@ export * as CenterDemos from './demos/core/Center';
 export * as ContainerDemos from './demos/core/Container';
 export * as DividerDemos from './demos/core/Divider';
 export * as NumberInputDemos from './demos/core/NumberInput';
+export * as PaperDemos from './demos/core/Paper';
 
 // Other packages
 export * as PrismDemos from './demos/prism';

--- a/packages/svelteui-demos/src/lib/index.ts
+++ b/packages/svelteui-demos/src/lib/index.ts
@@ -6,6 +6,7 @@ export * as CodeDemoExamples from './examples/CodeDemo';
 export * as ConfiguratorExamples from './examples/Configurator';
 
 // @svelteui/core
+export * as AnchorDemos from './demos/core/Anchor';
 export * as ButtonDemos from './demos/core/Button';
 export * as CenterDemos from './demos/core/Center';
 export * as ContainerDemos from './demos/core/Container';


### PR DESCRIPTION
Documentation and demos for components `Paper` and `Anchor`:

![image](https://user-images.githubusercontent.com/25725586/171192722-b469c239-834e-48e9-9011-679129f3c7b1.png)

![image](https://user-images.githubusercontent.com/25725586/171192778-9d2bff48-893a-4f37-a529-dae6e66a3dfe.png)

**Note**: I noticed that component `Paper` does not support controlling the `padding`, perhaps it is something we should support. If so, I can do it in this PR

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `npm run lint` or just run `npm run repo:prepush` and check to see if it's passing.
