### PR TITLE
[docs] Popper

### DIFF
--- a/docs/src/includes/sidebar.md
+++ b/docs/src/includes/sidebar.md
@@ -61,6 +61,7 @@
   - [BrowserRender](core/browser-render)
   - [Divider](core/divider)
   - [Paper](core/paper)
+  - [Popper](core/popper)
   - [ServerRender](core/server-render)
   - [Fragment](core/fragment)
 - ### SvelteUI Actions

--- a/docs/src/pages/core/popper.md
+++ b/docs/src/pages/core/popper.md
@@ -1,0 +1,48 @@
+---
+title: Popper
+group: 'svelteuidev-core'
+packageGroup: '@svelteuidev/core'
+slug: /core/popper/
+category: 'misc'
+description: 'Render dropdown related to a reference component or in portal'
+import: "import { Popper } from '@svelteuidev/core';"
+source: 'svelte-core/src/lib/components/Popper/Popper.svelte'
+docs: 'core/popper.md'
+---
+
+<script>
+    import { Demo, PopperDemos } from '@svelteuidev/demos';
+    import { Heading, Preview } from 'components';
+</script>
+
+<Heading />
+
+## Usage
+
+Popper is an utility component used under the hood in `Menu`(not implement yet), `Popover` (not implement yet) and [`Tooltip`](core/tooltip). You can use it to create your own dropdowns and popovers.
+
+To use Popper, add the following required props:
+
+* `reference` - element (HTML element) based on which popper will be positioned
+* `mounted` - current poppper opened state: `true` to display, `false` to hide
+
+```svelte
+<script>
+    import { Popper } from '@svelteuidev/core';
+</script>
+
+<Button bind:element={reference} on:click={() => mounted = !mounted }>Click here</Button>
+<Popper {reference} {mounted}>
+    <div>Popper content</div>
+</Popper>
+```
+
+## Position
+
+Popper position is controlled by these props:
+
+* `position` - left, right, bottom or top
+* `placement` - start, right or center
+* `gutter` - spacing between the reference element and the popper dropdown, in px
+* `withArrow` - displays an arrow between the reference element and the popper dropdown, takes into consideration the `position` and `placement`
+* `arrowSize` - the arrow size in px

--- a/docs/src/pages/core/popper.md
+++ b/docs/src/pages/core/popper.md
@@ -46,3 +46,14 @@ Popper position is controlled by these props:
 * `gutter` - spacing between the reference element and the popper dropdown, in px
 * `withArrow` - displays an arrow between the reference element and the popper dropdown, takes into consideration the `position` and `placement`
 * `arrowSize` - the arrow size in px
+
+<Demo demo={PopperDemos.configurator} />
+
+# z-index
+
+By default, Popper has `z-index: 1`, but it can be changed with the `zIndex` prop:
+
+
+```svelte
+<Popper zIndex={10} {...$$restProps} />
+```

--- a/packages/svelteui-core/src/lib/components/Popper/Popper.svelte
+++ b/packages/svelteui-core/src/lib/components/Popper/Popper.svelte
@@ -171,6 +171,12 @@
 				break;
 		}
 
+		// remove any offset measurements related to the parent
+		// element of the popper
+		const offsetParent = element.offsetParent as HTMLElement;
+		left -= offsetParent.offsetLeft;
+		top -= offsetParent.offsetTop;
+
 		return {
 			top: top,
 			bottom: top + element.clientHeight,

--- a/packages/svelteui-demos/src/lib/demos/core/Popper/Popper.demo.configurator.svelte
+++ b/packages/svelteui-demos/src/lib/demos/core/Popper/Popper.demo.configurator.svelte
@@ -1,0 +1,81 @@
+<script lang="ts" context="module">
+	import type { ConfiguratorDemoType, ConfiguratorDemoConfiguration } from '$lib/types';
+
+	const codeTemplate = (props: string, children: string) => `
+<script>
+  import { Box, Button, Popper } from '@svelteuidev/core';
+
+  let reference;
+<\/script>
+
+<Center>
+	<Button bind:element={reference}>Reference element</Button>
+    <Popper mounted={true} arrowOverride={{ backgroundColor: '$gray100' }} {reference} ${props}>
+        <Box css={{ backgroundColor: '$gray100', borderRadius: 5, padding: '30px' }}>
+			<Center>
+				Popper content
+			</Center>
+		</Box>
+    </Popper>
+</Center>
+`;
+
+	export const type: ConfiguratorDemoType['type'] = 'configurator';
+
+	export const configuration: ConfiguratorDemoConfiguration = {
+		codeTemplate,
+		configurator: [
+			{
+				name: 'position',
+				type: 'select',
+				data: [
+					{ label: 'bottom', value: 'bottom' },
+					{ label: 'top', value: 'top' },
+					{ label: 'left', value: 'left' },
+					{ label: 'right', value: 'right' }
+				],
+				initialValue: 'bottom',
+				defaultValue: 'bottom'
+			},
+			{
+				name: 'placement',
+				type: 'select',
+				data: [
+					{ label: 'start', value: 'start' },
+					{ label: 'center', value: 'center' },
+					{ label: 'end', value: 'end' }
+				],
+				initialValue: 'start',
+				defaultValue: 'start'
+			},
+			{ name: 'gutter', type: 'number', min: -20, max: 20, initialValue: 5, defaultValue: 5 },
+			{ name: 'arrowSize', label: "Arrow size", type: 'number', min: 0, max: 15, initialValue: 5, defaultValue: 5 },
+			{ name: 'withArrow', label: 'With arrow', type: 'boolean', initialValue: true, defaultValue: true }
+		]
+	};
+</script>
+
+<script lang="ts">
+	import type { PopperStyles } from '@svelteuidev/core';
+	import { Box, Button, Center, Popper } from '@svelteuidev/core';
+
+	export let props: PopperStyles.PopperProps = {};
+    
+    let reference;
+</script>
+
+<Center>
+	<Button bind:element={reference}>Reference element</Button>
+    <Popper
+        mounted={true}
+        arrowOverride={{ backgroundColor: '$gray100' }}
+        {reference}
+        {...props}
+    >
+        <Box css={{ backgroundColor: '$gray100', borderRadius: 5, padding: '30px' }}>
+			<Center>
+				Popper content
+			</Center>
+		</Box>
+    </Popper>
+</Center>

--- a/packages/svelteui-demos/src/lib/demos/core/Popper/index.ts
+++ b/packages/svelteui-demos/src/lib/demos/core/Popper/index.ts
@@ -1,0 +1,1 @@
+export * as configurator from './Popper.demo.configurator.svelte';

--- a/packages/svelteui-demos/src/lib/index.ts
+++ b/packages/svelteui-demos/src/lib/index.ts
@@ -13,6 +13,7 @@ export * as ContainerDemos from './demos/core/Container';
 export * as DividerDemos from './demos/core/Divider';
 export * as NumberInputDemos from './demos/core/NumberInput';
 export * as PaperDemos from './demos/core/Paper';
+export * as PopperDemos from './demos/core/Popper';
 
 // Other packages
 export * as PrismDemos from './demos/prism';


### PR DESCRIPTION
Documentation for `Popper`

- Fix in popper where it should take into account the offset of its more direct parent in its position so that it always correctly positioned on its reference element. 

![image](https://user-images.githubusercontent.com/25725586/171282643-f4900855-2c45-4baf-a281-c2da6bf2a70b.png)
 
### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `npm run lint` or just run `npm run repo:prepush` and check to see if it's passing.
