### PR TITLE
[core]: run package for tests before running the tests (fixes failing CI)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,6 @@ jobs:
       - run: npm ci
       - run: npm run format
       - run: npm run lint
-      - run: |
-          npm run package:tests
-          npm run test
+      - run: npm run package
+      - run: npm run test
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,6 @@ jobs:
       - run: npm run format
       - run: npm run lint
       - run: |
-        npm run package:tests
-        npm run test
+          npm run package:tests
+          npm run test
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,4 +18,7 @@ jobs:
       - run: npm ci
       - run: npm run format
       - run: npm run lint
-      - run: npm test
+      - run: |
+        npm run package:tests
+        npm run test
+

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "postinstall": "npx patch-package",
     "lint": "turbo run lint --parallel",
     "package": "npm run clean && turbo run package --parallel",
-    "package:tests": "npm run clean && turbo run package --filter=@svelteuidev/tests",
     "pre-commit": "lint-staged",
     "pre-release": "deno run --unstable --allow-read --allow-write ./scripts/pre-release.ts",
     "prepare": "husky install",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "postinstall": "npx patch-package",
     "lint": "turbo run lint --parallel",
     "package": "npm run clean && turbo run package --parallel",
+    "package:tests": "npm run clean && turbo run package --filter=@svelteuidev/tests",
     "pre-commit": "lint-staged",
     "pre-release": "deno run --unstable --allow-read --allow-write ./scripts/pre-release.ts",
     "prepare": "husky install",


### PR DESCRIPTION
* Fix failing CI by running the `package` command for tests before running the tests (it requires or else core does not have access to the testing package)

Tried only packaging the tests package, but composables is also required so I ended up packaging all, but perhaps later we only do those 2, since core will become heavier and can cost on the CI in terms of time.

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `npm run lint` or just run `npm run repo:prepush` and check to see if it's passing.
