### PR TITLE
[@svelteui/core] Early return for popper if no arrow is enabled

### DIFF
--- a/packages/svelteui-core/src/lib/components/Popper/Popper.svelte
+++ b/packages/svelteui-core/src/lib/components/Popper/Popper.svelte
@@ -54,6 +54,9 @@
 				left: `${x}px`,
 				top: `${y}px`
 			});
+			
+			// return early if no arrow is wanted in the popper
+			if (!withArrow) return;
 
 			const { x: arrowX, y: arrowY } = middlewareData.arrow;
 			const _position = placement.split('-')[0];


### PR DESCRIPTION
Early return for popper if arrow is not enabled

Fixes #117 

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `npm run lint` or just run `npm run repo:prepush` and check to see if it's passing.
