### PR TITLE
[core]: add radix-icons-svelte to vite deps to fix core tests and prism

### DIFF
--- a/packages/svelteui-core/src/lib/components/Card/Card.svelte
+++ b/packages/svelteui-core/src/lib/components/Card/Card.svelte
@@ -18,10 +18,10 @@
 		const firstChild = element.children[0] as HTMLDivElement;
 		const lastChild = element.children[nodeLength - 1] as HTMLDivElement;
 
-		if (firstChild.id === 'svelteui_card_section') {
+		if (firstChild?.id === 'svelteui_card_section') {
 			firstChild.style.marginTop = `${-1 * theme.fn.size({ size: padding, sizes: theme.space })}px`;
 		}
-		if (lastChild.id === 'svelteui_card_section') {
+		if (lastChild?.id === 'svelteui_card_section') {
 			// prettier-ignore
 			lastChild.style.marginBottom = `${-1 * theme.fn.size({ size: padding, sizes: theme.space })}px`;
 		}

--- a/packages/svelteui-core/src/lib/components/Modal/Modal.svelte
+++ b/packages/svelteui-core/src/lib/components/Modal/Modal.svelte
@@ -59,7 +59,7 @@
 	$: {
 		onMount(() => {
 			if (!trapFocus) {
-				typeof window !== undefined ? window.addEventListener('keydown', closeOnEscapePress) : null;
+				typeof window !== "undefined" ? window.addEventListener('keydown', closeOnEscapePress) : null;
 			}
 		});
 	}

--- a/packages/svelteui-core/svelte.config.js
+++ b/packages/svelteui-core/svelte.config.js
@@ -33,7 +33,10 @@ const config = {
 			},
 			test: {
 				globals: true,
-				environment: 'jsdom'
+				environment: 'jsdom',
+				deps: {
+					inline: ['radix-icons-svelte']
+				}
 			},
 			server: {
 				fs: {

--- a/packages/svelteui-demos/src/lib/demos/core/Checkbox/CheckboxGroup.demo.configurator.svelte
+++ b/packages/svelteui-demos/src/lib/demos/core/Checkbox/CheckboxGroup.demo.configurator.svelte
@@ -50,7 +50,8 @@
 </script>
 
 <script lang="ts">
-	import { CheckboxGroup, Center, type CheckboxGroupStyles } from '@svelteuidev/core';
+	import { CheckboxGroup, Center } from '@svelteuidev/core';
+	import type { CheckboxGroupStyles } from '@svelteuidev/core';
 
 	export let props: CheckboxGroupStyles.CheckboxGroupProps = {};
 </script>

--- a/packages/svelteui-prism/svelte.config.js
+++ b/packages/svelteui-prism/svelte.config.js
@@ -26,6 +26,9 @@ const config = {
 		},
 		/** @type {import('vite').UserConfig} */
 		vite: {
+			deps: {
+				inline: ['radix-icons-svelte']
+			},
 			test: {
 				globals: true,
 				environment: 'jsdom'

--- a/packages/svelteui-prism/svelte.config.js
+++ b/packages/svelteui-prism/svelte.config.js
@@ -29,6 +29,9 @@ const config = {
 			deps: {
 				inline: ['radix-icons-svelte']
 			},
+			optimizeDeps: {
+				exclude: ['radix-icons-svelte']
+			},
 			test: {
 				globals: true,
 				environment: 'jsdom'


### PR DESCRIPTION
* Add `radix-icons-svelte` to vite `deps` to fix failing tests for core and running `npm run dev` in prism package
* Fix linting problem in the `demos` package

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [x] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.

### Tests

- [x] Run the tests with `npm test` and lint the project with `npm run lint` or just run `npm run repo:prepush` and check to see if it's passing.
