### PR TITLE
[@svelteui/prism]: fix prism error when updating code

### DIFF
--- a/packages/svelteui-prism/src/lib/dist/Prism/Prism.svelte
+++ b/packages/svelteui-prism/src/lib/dist/Prism/Prism.svelte
@@ -266,9 +266,8 @@
 	{/if}
 	<pre
 		class={prismClasses}
-		data-line={highlightLines}>
-		<code class="language-{language}">
-			{@html prettyCode}
-		</code>
+		data-line={highlightLines}
+	>
+		{@html prettyCode}
 	</pre>
 </div>


### PR DESCRIPTION
So when I developed the initial prism solution, I did not noticed I was using two approaches of highlighting :facepalm:. We were using both the pre + code approach (which is automatic) and the manual API.

After thinking it was a svelte problem and opening an issue on their side - https://github.com/sveltejs/svelte/issues/7604 - it is actually not a svelte problem per say, but the pre + code approach is not compatible since Prism already removes the DOM nodes, and when updating the values svelte tries to remove them but they already are removed.

Since we were using both the automatic and the "manual" approach, the logic solution is to move only to the manual approach, which already work fine - this means removing the <code> tag (really needs to be removed because even with this tag but with no  `language-<language>` class, Prism still tries to manipulate the DOM nodes).

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `npm run lint` or just run `npm run repo:prepush` and check to see if it's passing.
