### PR TITLE
[@svelteui/composables]: port old unit tests to the composables package

### DIFF
--- a/packages/svelteui-composables/package.json
+++ b/packages/svelteui-composables/package.json
@@ -45,6 +45,8 @@
     "pub": "npm publish package/",
     "pub:test": "npm publish package/",
     "sort": "npx sort-package-json",
+    "test": "vitest --run",
+    "test:watch": "vitest",
     "update:lockfile": "npm i",
     "watch": "svelte-kit package -w"
   },

--- a/packages/svelteui-composables/src/test/actions/components/use-click-outside.svelte
+++ b/packages/svelteui-composables/src/test/actions/components/use-click-outside.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+	import { clickoutside } from '$lib/actions/use-click-outside/use-click-outside';
+
+	export let open = true;
+</script>
+
+<div id="outside">
+	<div id="inside" use:clickoutside={{ enabled: open, callback: () => (open = false) }} />
+</div>

--- a/packages/svelteui-composables/src/test/actions/components/use-clipboard.svelte
+++ b/packages/svelteui-composables/src/test/actions/components/use-clipboard.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import { clipboard } from '$lib/actions/use-clipboard/use-clipboard';
+
+	export let text = 'This text will be copied';
+	export let callback;
+	export let callbackError;
+</script>
+
+<button
+	id="clipboard"
+	use:clipboard={text}
+	on:useclipboard={(event) => callback(event.detail)}
+	on:useclipboard-error={(event) => callbackError(event.detail)}
+>
+	Copy Me
+</button>

--- a/packages/svelteui-composables/src/test/actions/components/use-css-variable.svelte
+++ b/packages/svelteui-composables/src/test/actions/components/use-css-variable.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { cssvariable } from '$lib/actions/use-css-variable/use-css-variable';
+
+	export let cssVariables = { display: 'block', 'background-color': 'yellow' };
+</script>
+
+<div id="css-variable" use:cssvariable={cssVariables} />

--- a/packages/svelteui-composables/src/test/actions/components/use-download.svelte
+++ b/packages/svelteui-composables/src/test/actions/components/use-download.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { download } from '$lib/actions/use-download/use-download';
+
+	export let blob = new Blob([]);
+	export let filename = '';
+	export let callback;
+	export let callbackError;
+</script>
+
+<button
+	id="download"
+	use:download={{ blob: blob, filename: filename }}
+	on:usedownload={(event) => callback(event.detail)}
+	on:usedownload-error={(event) => callbackError(event.detail)}
+>
+	Download
+</button>

--- a/packages/svelteui-composables/src/test/actions/components/use-focus.svelte
+++ b/packages/svelteui-composables/src/test/actions/components/use-focus.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import { focus } from '$lib/actions/use-focus/use-focus';
+</script>
+
+<input id="focus" use:focus />

--- a/packages/svelteui-composables/src/test/actions/components/use-page-leave.svelte
+++ b/packages/svelteui-composables/src/test/actions/components/use-page-leave.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { pageleave } from '$lib/actions/use-page-leave/use-page-leave';
+
+	export let callback;
+</script>
+
+<div use:pageleave={() => callback()}>Leave</div>

--- a/packages/svelteui-composables/src/test/actions/components/use-tab-leave.svelte
+++ b/packages/svelteui-composables/src/test/actions/components/use-tab-leave.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { tableave } from '$lib/actions/use-tab-leave/use-tab-leave';
+
+	export let callback;
+</script>
+
+<div use:tableave={() => callback()}>Leave</div>

--- a/packages/svelteui-composables/src/test/actions/example.test.ts
+++ b/packages/svelteui-composables/src/test/actions/example.test.ts
@@ -1,0 +1,5 @@
+import { expect, test } from 'vitest';
+
+test('example test', async () => {
+	expect(1 + 1).eq(2);
+});

--- a/packages/svelteui-composables/src/test/actions/use-click-outside.test.ts
+++ b/packages/svelteui-composables/src/test/actions/use-click-outside.test.ts
@@ -1,0 +1,39 @@
+import { tick } from 'svelte';
+import { describe, expect, test, vi } from 'vitest';
+import { render } from '@testing-library/svelte';
+
+import UseClickOutside from './components/use-click-outside.svelte';
+
+describe('use-click-outside', () => {
+	test('clicks inside and outside a div and changes the state of a variable', async () => {
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		const { component } = render(UseClickOutside, { target: container });
+		expect(component).toBeTruthy();
+
+		const writeTextMock = vi.fn();
+		Object.assign(window.navigator, {
+			clipboard: {
+				writeText: writeTextMock
+			}
+		});
+
+		const inside = document.getElementById('inside');
+		inside.click();
+		expect(component.$$.ctx[0]).eq(true);
+
+		const outside = document.getElementById('outside');
+		outside.click();
+		expect(component.$$.ctx[0]).eq(false);
+
+		component.$set({ open: true });
+		await tick();
+		expect(component.$$.ctx[0]).eq(true);
+
+		component.$set({ open: false });
+		await tick();
+		expect(component.$$.ctx[0]).eq(false);
+
+		component.$destroy();
+	});
+});

--- a/packages/svelteui-composables/src/test/actions/use-clipboard.test.ts
+++ b/packages/svelteui-composables/src/test/actions/use-clipboard.test.ts
@@ -1,0 +1,59 @@
+import { tick } from 'svelte';
+import { describe, expect, test, vi } from 'vitest';
+import { render } from '@testing-library/svelte';
+
+import UseClipboard from './components/use-clipboard.svelte';
+
+describe('use-clipboard', () => {
+	test('copies text to clipboard', async () => {
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+
+		const callbackMock = vi.fn();
+		const callbackErrorMock = vi.fn();
+		const { component } = render(UseClipboard, {
+			target: container,
+			props: {
+				text: 'This text will be copied',
+				callback: callbackMock,
+				callbackError: callbackErrorMock
+			}
+		});
+		expect(component).toBeTruthy();
+
+		const writeTextMock = vi.fn();
+		Object.assign(window.navigator, {
+			clipboard: {
+				writeText: writeTextMock
+			}
+		});
+
+		const btn = document.getElementById('clipboard');
+		btn.click();
+		await tick();
+		expect(writeTextMock).toHaveBeenCalledTimes(1);
+		expect(writeTextMock).toHaveBeenCalledWith('This text will be copied');
+		expect(callbackMock).toHaveBeenCalledTimes(1);
+		expect(callbackMock).toHaveBeenCalledWith('This text will be copied');
+		expect(callbackErrorMock).toHaveBeenCalledTimes(0);
+
+		writeTextMock.mockImplementation(() => {
+			throw Error();
+		});
+		btn.click();
+		await tick();
+		expect(writeTextMock).toHaveBeenCalledTimes(2);
+		expect(writeTextMock).toHaveBeenCalledWith('This text will be copied');
+		expect(callbackMock).toHaveBeenCalledTimes(1);
+		expect(callbackErrorMock).toHaveBeenCalledTimes(1);
+
+		await component.$set({ text: '' });
+		// eslint-disable-next-line @typescript-eslint/no-empty-function
+		writeTextMock.mockImplementation(() => {});
+		btn.click();
+		expect(writeTextMock).toHaveBeenCalledTimes(2);
+		expect(writeTextMock).toHaveBeenCalledWith('This text will be copied');
+		expect(callbackMock).toHaveBeenCalledTimes(1);
+		expect(callbackErrorMock).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/svelteui-composables/src/test/actions/use-css-variable.test.ts
+++ b/packages/svelteui-composables/src/test/actions/use-css-variable.test.ts
@@ -1,0 +1,25 @@
+import { tick } from 'svelte';
+import { describe, expect, test } from 'vitest';
+import { render } from '@testing-library/svelte';
+
+import UseCssVariable from './components/use-css-variable.svelte';
+
+describe('use-css-variable', () => {
+	test('applies CSS properties to a HTML element', async () => {
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		const { component } = render(UseCssVariable, { target: container });
+		expect(component).toBeTruthy();
+
+		const div = document.getElementById('css-variable');
+		expect(div.style.getPropertyValue('--display')).eq('block');
+		expect(div.style.getPropertyValue('--background-color')).eq('yellow');
+
+		component.$set({ cssVariables: { 'background-color': 'green', color: 'purple' } });
+		await tick();
+
+		expect(div.style.getPropertyValue('--display')).eq('');
+		expect(div.style.getPropertyValue('--color')).eq('purple');
+		expect(div.style.getPropertyValue('--background-color')).eq('green');
+	});
+});

--- a/packages/svelteui-composables/src/test/actions/use-download.test.ts
+++ b/packages/svelteui-composables/src/test/actions/use-download.test.ts
@@ -1,0 +1,62 @@
+import { tick } from 'svelte';
+import { describe, expect, test, vi } from 'vitest';
+import { render } from '@testing-library/svelte';
+
+import UseDownload from './components/use-download.svelte';
+
+describe('use-download', () => {
+	test('downloads a file', async () => {
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+
+		const callbackMock = vi.fn();
+		const callbackErrorMock = vi.fn();
+		const { component } = render(UseDownload, {
+			target: container,
+			props: {
+				callback: callbackMock,
+				callbackError: callbackErrorMock
+			}
+		});
+		expect(component).toBeTruthy();
+
+		// setup mock function for 'createObjectURL' and
+		// 'revokeObjectURL which is not implement by JSDom
+		const createObjectURLMock = vi.fn().mockImplementation(() => '');
+		const revokeObjectURLMock = vi.fn();
+		global.URL.createObjectURL = createObjectURLMock;
+		global.URL.revokeObjectURL = revokeObjectURLMock;
+
+		const btn = document.getElementById('download');
+		btn.click();
+		await tick();
+		expect(createObjectURLMock).toHaveBeenCalledTimes(1);
+		expect(createObjectURLMock).toBeCalledWith(new Blob([]));
+		expect(revokeObjectURLMock).toHaveBeenCalledTimes(1);
+		expect(callbackMock).toHaveBeenCalledTimes(1);
+		expect(callbackMock).toHaveBeenCalledWith({ blob: new Blob([]), filename: '' });
+		expect(callbackErrorMock).toHaveBeenCalledTimes(0);
+
+		createObjectURLMock.mockImplementation(() => {
+			throw Error();
+		});
+		btn.click();
+		await tick();
+		expect(createObjectURLMock).toHaveBeenCalledTimes(2);
+		expect(createObjectURLMock).toBeCalledWith(new Blob([]));
+		expect(revokeObjectURLMock).toHaveBeenCalledTimes(1);
+		expect(callbackMock).toHaveBeenCalledTimes(1);
+		expect(callbackErrorMock).toHaveBeenCalledTimes(1);
+
+		createObjectURLMock.mockImplementation(() => '');
+		await component.$set({ filename: 'test.txt' });
+		btn.click();
+		await tick();
+		expect(createObjectURLMock).toHaveBeenCalledTimes(3);
+		expect(createObjectURLMock).toBeCalledWith(new Blob([]));
+		expect(revokeObjectURLMock).toHaveBeenCalledTimes(2);
+		expect(callbackMock).toHaveBeenCalledTimes(2);
+		expect(callbackMock).toHaveBeenCalledWith({ blob: new Blob([]), filename: 'test.txt' });
+		expect(callbackErrorMock).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/svelteui-composables/src/test/actions/use-focus.test.ts
+++ b/packages/svelteui-composables/src/test/actions/use-focus.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'vitest';
+import { render } from '@testing-library/svelte';
+
+import UseFocus from './components/use-focus.svelte';
+
+describe('use-focus', () => {
+	test('focus on an input', async () => {
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+
+		const { component } = render(UseFocus, { target: container });
+
+		expect(component).toBeTruthy();
+		expect(document.activeElement.id).eq('focus');
+	});
+});

--- a/packages/svelteui-composables/src/test/actions/use-page-leave.test.ts
+++ b/packages/svelteui-composables/src/test/actions/use-page-leave.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test, vi } from 'vitest';
+import { render } from '@testing-library/svelte';
+
+import UsePageLeave from './components/use-page-leave.svelte';
+
+describe('use-page-leave', () => {
+	test('calls callback on page leave', async () => {
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+
+		const callbackMock = vi.fn();
+		const { component } = render(UsePageLeave, {
+			target: container,
+			props: {
+				callback: callbackMock
+			}
+		});
+		expect(component).toBeTruthy();
+
+		document.documentElement.dispatchEvent(new Event('mouseleave'));
+		expect(callbackMock).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/svelteui-composables/src/test/actions/use-tab-leave.test.ts
+++ b/packages/svelteui-composables/src/test/actions/use-tab-leave.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test, vi } from 'vitest';
+import { render } from '@testing-library/svelte';
+
+import UseTabLeave from './components/use-tab-leave.svelte';
+
+describe('use-tab-leave', () => {
+	test('calls callback on tab leave', async () => {
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+
+		const callbackMock = vi.fn();
+		const { component } = render(UseTabLeave, {
+			target: container,
+			props: {
+				callback: callbackMock
+			}
+		});
+		expect(component).toBeTruthy();
+
+		document.dispatchEvent(new Event('visibilitychange'));
+		expect(callbackMock).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/svelteui-composables/src/test/shared/is.test.ts
+++ b/packages/svelteui-composables/src/test/shared/is.test.ts
@@ -1,0 +1,153 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+import { describe, expect, test } from 'vitest';
+
+import {
+	isBoolean,
+	isClient,
+	isFunction,
+	isNumber,
+	isObject,
+	isString,
+	isWindow,
+	now,
+	rand,
+	sleep,
+	timestamp
+} from '$lib';
+
+describe('is', () => {
+	describe('isClient', () => {
+		test('returns true when window is defined', () => {
+			expect(isClient).eq(true);
+		});
+	});
+
+	describe('isBoolean', () => {
+		test('returns true when the value is a boolean', () => {
+			expect(isBoolean(true)).eq(true);
+			expect(isBoolean(false)).eq(true);
+		});
+
+		test('returns false when the value is not a boolean', () => {
+			expect(isBoolean(1)).eq(false);
+		});
+	});
+
+	describe('isFunction', () => {
+		test('returns true when the value is a function', () => {
+			expect(
+				isFunction(() => {
+					return;
+				})
+			).eq(true);
+			expect(
+				isFunction(function () {
+					return;
+				})
+			).eq(true);
+		});
+
+		test('returns false when the value is not a function', () => {
+			expect(isFunction(1)).eq(false);
+		});
+	});
+
+	describe('isNumber', () => {
+		test('returns true when the value is a number', () => {
+			expect(isNumber(1)).eq(true);
+			expect(isNumber(1.2)).eq(true);
+			expect(isNumber(NaN)).eq(true);
+		});
+
+		test('returns false when the value is not a number', () => {
+			expect(isNumber('test')).eq(false);
+			expect(
+				isNumber(() => {
+					return;
+				})
+			).eq(false);
+			expect(isNumber(true)).eq(false);
+		});
+	});
+
+	describe('isString', () => {
+		test('returns true when the value is a string', () => {
+			expect(isString('test')).eq(true);
+			expect(isString(['t'].toString())).eq(true);
+		});
+
+		test('returns false when the value is not a string', () => {
+			expect(isString(1)).eq(false);
+			expect(
+				isString(() => {
+					return;
+				})
+			).eq(false);
+			expect(isString(true)).eq(false);
+		});
+	});
+
+	describe('isObject', () => {
+		test('returns true when the value is an object', () => {
+			expect(isObject({})).eq(true);
+			expect(isObject({ key: 1 })).eq(true);
+		});
+
+		test('returns false when the value is not an object', () => {
+			expect(isObject(1)).eq(false);
+			expect(
+				isObject(() => {
+					return;
+				})
+			).eq(false);
+			expect(isObject(true)).eq(false);
+		});
+	});
+
+	describe('isWindow', () => {
+		test('returns true when the value is a window', () => {
+			expect(isWindow(window)).eq(true);
+		});
+
+		test('returns false when the value is not a window', () => {
+			expect(isWindow(1)).eq(false);
+			expect(
+				isWindow(() => {
+					return;
+				})
+			).eq(false);
+			expect(isWindow(true)).eq(false);
+		});
+	});
+
+	describe('now', () => {
+		test('returns the current timestamp', () => {
+			expect(now()).eq(Date.now());
+			expect(now()).toBeTypeOf(typeof 1);
+		});
+	});
+
+	describe('timestamp', () => {
+		test('returns the current timestamp', () => {
+			expect(timestamp()).eq(Date.now());
+			expect(timestamp()).toBeTypeOf(typeof 1);
+		});
+	});
+
+	describe('sleep', () => {
+		test('awaits a certain time interval and then returns', async () => {
+			const start = Date.now();
+			await sleep(100);
+			const end = Date.now();
+			expect(end - start).greaterThanOrEqual(90);
+		});
+	});
+
+	describe('rand', () => {
+		test('returns a random number between an interval of numbers', () => {
+			const value = rand(1, 4);
+			expect(value).toBeGreaterThanOrEqual(1);
+			expect(value).toBeLessThanOrEqual(4);
+		});
+	});
+});

--- a/packages/svelteui-composables/src/test/shared/random-id.test.ts
+++ b/packages/svelteui-composables/src/test/shared/random-id.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from 'vitest';
+
+import { randomID } from '$lib';
+
+describe('random-id', () => {
+	test('returns a random string ID', () => {
+		const id = randomID();
+		expect(id.startsWith('svelteui-')).toBeTruthy();
+		expect(id.length).eq(17);
+	});
+});

--- a/packages/svelteui-composables/src/test/shared/time.test.ts
+++ b/packages/svelteui-composables/src/test/shared/time.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'vitest';
+
+import { dateTimeString } from '$lib';
+
+describe('time', () => {
+	test('returns a date time string based on locale', () => {
+		const timestamp = Date.parse('25 Apr 1974 22:55:00 GMT');
+		let result = dateTimeString(timestamp, 'en-US', {
+			dateStyle: 'short',
+			timeStyle: 'short',
+			timeZone: 'utc'
+		});
+		expect(result).eq('4/25/74, 10:55 PM');
+
+		result = dateTimeString(timestamp, 'en-US', {
+			dateStyle: 'full',
+			timeStyle: 'medium',
+			timeZone: 'utc'
+		});
+		expect(result).eq('Thursday, April 25, 1974 at 10:55:00 PM');
+
+		result = dateTimeString(timestamp, 'en-US', {
+			dateStyle: 'medium',
+			timeStyle: 'medium',
+			timeZone: 'utc'
+		});
+		expect(result).eq('Apr 25, 1974, 10:55:00 PM');
+
+		result = dateTimeString(timestamp, 'pt', {
+			dateStyle: 'full',
+			timeStyle: 'medium',
+			timeZone: 'utc'
+		});
+		expect(result).eq('quinta-feira, 25 de abril de 1974 22:55:00');
+
+		result = dateTimeString(timestamp, 'pt', {
+			dateStyle: 'full',
+			timeStyle: 'medium',
+			timeZone: 'utc'
+		});
+		expect(result).eq('quinta-feira, 25 de abril de 1974 22:55:00');
+	});
+});

--- a/packages/svelteui-composables/src/test/utilities/example.test.ts
+++ b/packages/svelteui-composables/src/test/utilities/example.test.ts
@@ -1,0 +1,5 @@
+import { expect, test } from 'vitest';
+
+test('example test', async () => {
+	expect(1 + 1).eq(2);
+});

--- a/packages/svelteui-composables/src/test/utilities/use-os.test.ts
+++ b/packages/svelteui-composables/src/test/utilities/use-os.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+import * as jsdom from 'jsdom';
+
+import { useOs } from '$lib';
+
+describe('use-os', () => {
+	beforeEach(() => {
+		const document = new jsdom.JSDOM(
+			"<!doctype html><html><head><meta charset='utf-8'></head><body></body></html>"
+		);
+		const window = document.window;
+		global.document = window.document;
+		global.window = window;
+	});
+
+	test('returns the respective OS of the current window with a certain platform', () => {
+		Object.defineProperty(window.navigator, 'platform', {
+			get: () => 'Macintosh',
+			configurable: true
+		});
+		expect(useOs()).eq('macos');
+
+		Object.defineProperty(window.navigator, 'platform', {
+			get: () => 'iPhone'
+		});
+		expect(useOs()).eq('ios');
+
+		Object.defineProperty(window.navigator, 'platform', {
+			get: () => 'Win64'
+		});
+		expect(useOs()).eq('windows');
+	});
+
+	test('returns the respective OS of the current window with a certain userAgent', () => {
+		Object.defineProperty(window.navigator, 'userAgent', {
+			get: () => 'Macintosh',
+			configurable: true
+		});
+		expect(useOs()).eq('macos');
+
+		Object.defineProperty(window.navigator, 'userAgent', {
+			get: () => '(linux)',
+			configurable: true
+		});
+		expect(useOs()).eq('linux');
+
+		Object.defineProperty(window.navigator, 'userAgent', {
+			get: () => 'iPhone'
+		});
+		expect(useOs()).eq('ios');
+
+		Object.defineProperty(window.navigator, 'userAgent', {
+			get: () => 'android'
+		});
+		expect(useOs()).eq('android');
+
+		Object.defineProperty(window.navigator, 'userAgent', {
+			get: () => 'Win64'
+		});
+		expect(useOs()).eq('windows');
+	});
+
+	test('returns undetermined when there is no window', () => {
+		global.window = undefined;
+		expect(useOs()).eq('undetermined');
+	});
+});

--- a/packages/svelteui-composables/src/test/utilities/use-raf-fn.test.ts
+++ b/packages/svelteui-composables/src/test/utilities/use-raf-fn.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import { useRafFn } from '$lib';
+
+describe('raf-fn', () => {
+	test("calls a function on every 'requestAnimationFrame'", () => {
+		const callbackMock = vi.fn();
+		useRafFn(callbackMock);
+		expect(callbackMock).toHaveBeenCalled();
+	});
+
+	test('does not call function if the window is not defined', () => {
+		const callbackMock = vi.fn(() => {
+			throw new Error();
+		});
+		useRafFn(callbackMock);
+		expect(callbackMock).toHaveBeenCalled();
+	});
+
+	test('pauses the loop on request animation frame calls', () => {
+		const callbackMock = vi.fn();
+		const { pause } = useRafFn(callbackMock);
+		expect(callbackMock).toHaveBeenCalled();
+
+		pause();
+		expect(callbackMock).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
Port tests from old utilities and actions packages to the composables package

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `npm run lint` or just run `npm run repo:prepush` and check to see if it's passing.
