### PR TITLE
[@svelteui/core]: fallback to default theme if no provider was used

### DIFF
--- a/packages/svelteui-core/src/lib/styles/engine/create-styles.ts
+++ b/packages/svelteui-core/src/lib/styles/engine/create-styles.ts
@@ -2,7 +2,7 @@
 import { css } from '../index.js';
 import { cssFactory } from './css.js';
 import { fromEntries } from './utils/from-entries/from-entries.js';
-import { useSvelteUIThemeContext } from '$lib/styles';
+import { useSvelteUITheme, useSvelteUIThemeContext } from '$lib/styles';
 import type { CSS } from '$lib/styles';
 import type { SvelteUITheme } from '$lib/styles';
 
@@ -32,7 +32,7 @@ export function createStyles<Params = void>(
 
 	function useStyles(params: Params = {} as Params) {
 		/** create our new theme object */
-		const theme: SvelteUITheme = useSvelteUIThemeContext().theme;
+		const theme: SvelteUITheme = useSvelteUIThemeContext()?.theme || useSvelteUITheme();
 		const { cx } = cssFactory();
 
 		/** store the created dirty object in a variable */

--- a/packages/svelteui-core/src/lib/styles/theme/functions/fns/radius/radius.ts
+++ b/packages/svelteui-core/src/lib/styles/theme/functions/fns/radius/radius.ts
@@ -1,8 +1,8 @@
-import { useSvelteUIThemeContext } from '../../../SvelteUIProvider';
+import { useSvelteUITheme, useSvelteUIThemeContext } from '../../../SvelteUIProvider';
 import type { SvelteUINumberSize } from '$lib/styles';
 
 export function radius(radii?: SvelteUINumberSize): number | string {
-	const theme = useSvelteUIThemeContext().theme;
+	const theme = useSvelteUIThemeContext()?.theme || useSvelteUITheme();
 
 	if (typeof radii === 'number') {
 		return radii;

--- a/packages/svelteui-core/src/lib/styles/theme/functions/fns/theme-color/theme-color.ts
+++ b/packages/svelteui-core/src/lib/styles/theme/functions/fns/theme-color/theme-color.ts
@@ -1,10 +1,10 @@
-import { useSvelteUIThemeContext } from '../../../SvelteUIProvider';
+import { useSvelteUITheme, useSvelteUIThemeContext } from '../../../SvelteUIProvider';
 import type { SvelteUIOrAnyColor, SvelteUIColor } from '../../../index';
 
 export type ColorShades = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
 
 export function themeColor(color: SvelteUIOrAnyColor, shade: ColorShades = 0) {
-	const theme = useSvelteUIThemeContext().theme;
+	const theme = useSvelteUIThemeContext()?.theme || useSvelteUITheme();
 	let _shade = '50';
 
 	if (!isSvelteUIColor(color)) return color;

--- a/packages/svelteui-core/src/routes/index.svelte
+++ b/packages/svelteui-core/src/routes/index.svelte
@@ -50,8 +50,7 @@
 		createStyles,
 		useSvelteUITheme,
 		useSvelteUIThemeContext,
-		rgba,
-		type ProgressProps
+		rgba
 	} from '$lib';
 	import Gear from '../icons/Gear.svelte';
 


### PR DESCRIPTION
Falls back to default theme if no theme provider was used (meaning there is no theme saved in context).

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `npm run lint` or just run `npm run repo:prepush` and check to see if it's passing.
