### PR TITLE
[docs]: fix floating-ui problem with docs rollup config

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -18,6 +18,7 @@
 				"radix-icons-svelte": "^1.2.1"
 			},
 			"devDependencies": {
+				"@rollup/plugin-replace": "^4.0.0",
 				"@svelte-docs/core": "^0.10.13",
 				"@svelte-docs/publisher": "^0.2.3",
 				"@svelte-docs/themes": "^1.0.1",
@@ -171,6 +172,19 @@
 			},
 			"peerDependencies": {
 				"rollup": "^1.20.0||^2.0.0"
+			}
+		},
+		"node_modules/@rollup/plugin-replace": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-4.0.0.tgz",
+			"integrity": "sha512-+rumQFiaNac9y64OHtkHGmdjm7us9bo1PlbgQfdihQtuNxzjpaB064HbRnewUOggLQxVCCyINfStkgmBeQpv1g==",
+			"dev": true,
+			"dependencies": {
+				"@rollup/pluginutils": "^3.1.0",
+				"magic-string": "^0.25.7"
+			},
+			"peerDependencies": {
+				"rollup": "^1.20.0 || ^2.0.0"
 			}
 		},
 		"node_modules/@rollup/pluginutils": {
@@ -6609,6 +6623,16 @@
 				"builtin-modules": "^3.1.0",
 				"is-module": "^1.0.0",
 				"resolve": "^1.14.2"
+			}
+		},
+		"@rollup/plugin-replace": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-4.0.0.tgz",
+			"integrity": "sha512-+rumQFiaNac9y64OHtkHGmdjm7us9bo1PlbgQfdihQtuNxzjpaB064HbRnewUOggLQxVCCyINfStkgmBeQpv1g==",
+			"dev": true,
+			"requires": {
+				"@rollup/pluginutils": "^3.1.0",
+				"magic-string": "^0.25.7"
 			}
 		},
 		"@rollup/pluginutils": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,6 +13,7 @@
 		"radix-icons-svelte": "^1.2.1"
 	},
 	"devDependencies": {
+		"@rollup/plugin-replace": "^4.0.0",
 		"@svelte-docs/core": "^0.10.13",
 		"@svelte-docs/publisher": "^0.2.3",
 		"@svelte-docs/themes": "^1.0.1",
@@ -22,11 +23,12 @@
 	"scripts": {
 		"build": "rollup -c node_modules/@svelte-docs/core/rollup.config.js",
 		"autobuild": "rollup -c node_modules/@svelte-docs/core/rollup.config.js -w",
-		"dev": "npm run start:dev & npm run autobuild",
+		"prepare": "deno run --unstable --allow-read --allow-write ./prepare.ts",
+		"dev": "npm run prepare & npm run start:dev & npm run autobuild",
 		"start": "node node_modules/@svelte-docs/server",
 		"start:dev": "PORT=3000 node node_modules/@svelte-docs/server --dev --single",
 		"start:pagewatch": "node node_modules/@svelte-docs/core/watcher",
-		"deploy": "npm run build && deno run -A --unstable ../scripts/docs/build.ts",
+		"deploy": "npm run prepare & npm run build && deno run -A --unstable ../scripts/docs/build.ts",
 		"deploy:nobuild": "node node_modules/@svelte-docs/publisher"
 	}
 }

--- a/docs/prepare.ts
+++ b/docs/prepare.ts
@@ -1,0 +1,27 @@
+/**
+ * Temporary fix for using floating-ui dependency (for component Popper) with
+ * the Rollup configuration of svelte-docs.
+ */
+
+const rollupConfig = await Deno.readTextFile('./node_modules/@svelte-docs/core/rollup.config.js');
+
+// ignore this prepare step if the replace import
+// is already in the Rollup config, which means
+// this was already executed
+const alreadyPrepared = rollupConfig.search(/import replace from/);
+if (alreadyPrepared !== -1) {
+    Deno.exit();
+};
+
+// inject the replace import and the replace config
+// into the Rollup configuration
+let updatedConfig = `import replace from '@rollup/plugin-replace';\n` + rollupConfig;
+const injectPoint = updatedConfig.search(/commonjs\(\)/);
+const injectText = `replace({
+            'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+        }),
+`;
+updatedConfig = updatedConfig.slice(0, injectPoint + 12) + injectText + updatedConfig.slice(injectPoint + 12);
+
+await Deno.writeTextFile('./node_modules/@svelte-docs/core/rollup.config.js', "");
+await Deno.writeTextFile('./node_modules/@svelte-docs/core/rollup.config.js', updatedConfig);

--- a/packages/svelteui-demos/src/lib/demos/core/Popper/Popper.demo.configurator.svelte
+++ b/packages/svelteui-demos/src/lib/demos/core/Popper/Popper.demo.configurator.svelte
@@ -56,8 +56,8 @@
 				type: 'number',
 				min: 0,
 				max: 15,
-				initialValue: 5,
-				defaultValue: 5
+				initialValue: 3,
+				defaultValue: 3
 			},
 			{
 				name: 'withArrow',
@@ -86,7 +86,7 @@
 </script>
 
 <Button bind:element={reference} on:click={toggleMount}>Reference element</Button>
-<Popper arrowOverride={{ backgroundColor: '$gray100' }} {reference} {...props} {mounted}>
+<Popper override={{ '& .arrow': { backgroundColor: '$gray100' } }} {reference} {...props} {mounted}>
 	<Box css={{ backgroundColor: '$gray100', borderRadius: 5, padding: '30px' }}>
 		<Center>Popper content</Center>
 	</Box>


### PR DESCRIPTION
Temporary fix for the `process is undefined` problem in the docs for Popper + Tooltip, which resulted in a missing configuration in the Rollup config of svelte-docs, to use floating-ui.

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `npm run lint` or just run `npm run repo:prepush` and check to see if it's passing.
