### PR TITLE
[@svelteui/core]: add check for null element in popper

### DIFF
--- a/packages/svelteui-core/src/lib/components/Popper/Popper.svelte
+++ b/packages/svelteui-core/src/lib/components/Popper/Popper.svelte
@@ -51,6 +51,10 @@
 			placement: placementString as Placement,
 			middleware: middleware
 		}).then(({ x, y, placement, middlewareData }) => {
+			// the element might have been removed between the
+			// composition computing and its callback
+			if (!element) return;
+
 			Object.assign(element.style, {
 				left: `${x}px`,
 				top: `${y}px`


### PR DESCRIPTION
Between the `computePosition` start and its callback, the element might have been removed from DOM, so it might be null. A check was added to early return if that is the case.
Bug found by @LukasDoesDev and documented on discord.

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `npm run lint` or just run `npm run repo:prepush` and check to see if it's passing.
