### PR TITLE
[@svelteuidev/core] Use dispatch instead of props functions and fix prism

### DIFF
--- a/packages/svelteui-core/src/lib/components/Alert/Alert.styles.ts
+++ b/packages/svelteui-core/src/lib/components/Alert/Alert.styles.ts
@@ -13,7 +13,6 @@ export interface AlertProps extends DefaultProps {
 	iconProps: Record<string, unknown>;
 	withCloseButton: boolean;
 	closeButtonLabel: string;
-	onClose(...args: any[]): any;
 }
 
 export type AlertVariant = 'filled' | 'outline' | 'light';

--- a/packages/svelteui-core/src/lib/components/Alert/Alert.svelte
+++ b/packages/svelteui-core/src/lib/components/Alert/Alert.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { createEventDispatcher } from 'svelte';
 	import useStyles from './Alert.styles';
 	import { Box } from '../Box';
 	import { CloseButton } from '../ActionIcon';
@@ -16,9 +17,14 @@
 		iconSize: $$AlertProps['iconSize'] = 16,
 		iconProps: $$AlertProps['iconProps'] = {},
 		withCloseButton: $$AlertProps['withCloseButton'] = false,
-		closeButtonLabel: $$AlertProps['closeButtonLabel'] = undefined,
-		onClose: $$AlertProps['onClose'] = () => {};
+		closeButtonLabel: $$AlertProps['closeButtonLabel'] = undefined;
 	export { className as class };
+
+	const dispatch = createEventDispatcher();
+
+	function onClose() {
+		dispatch('close');
+	}
 
 	$: ({ cx, classes, getStyles } = useStyles({ color, radius, variant }));
 </script>

--- a/packages/svelteui-core/src/lib/components/Fragment/Fragment.styles.ts
+++ b/packages/svelteui-core/src/lib/components/Fragment/Fragment.styles.ts
@@ -4,9 +4,4 @@ import type { Fn } from '$lib/internal';
 export interface FragmentProps extends DefaultProps<HTMLElement> {
 	mode: 'fragment' | 'lifecycle';
 	context: Record<string, unknown>;
-	onCreate: Fn<unknown, unknown>;
-	onMount: Fn<unknown, unknown>;
-	beforeUpdate: Fn<unknown, unknown>;
-	afterUpdate: Fn<unknown, unknown>;
-	onDestroy: Fn<unknown, unknown>;
 }

--- a/packages/svelteui-core/src/lib/components/Fragment/Fragment.svelte
+++ b/packages/svelteui-core/src/lib/components/Fragment/Fragment.svelte
@@ -1,31 +1,25 @@
 <script lang="ts">
 	import { Overlay } from '../Overlay';
 	import { Text } from '../Text';
-	import { setContext, onMount, onDestroy, afterUpdate, beforeUpdate } from 'svelte';
+	import { createEventDispatcher, setContext, onMount, onDestroy, afterUpdate, beforeUpdate } from 'svelte';
 	import type { FragmentProps as $$FragmentProps } from './Fragment.styles';
 
 	export let mode: $$FragmentProps['mode'] = 'fragment';
 	export let context: $$FragmentProps['context'] = null;
-	export let onCreate: $$FragmentProps['onCreate'] = null;
-	export let onMountFn: $$FragmentProps['onMount'] = null;
-	export let beforeUpdateFn: $$FragmentProps['beforeUpdate'] = null;
-	export let afterUpdateFn: $$FragmentProps['afterUpdate'] = null;
-	export let onDestroyFn: $$FragmentProps['onDestroy'] = null;
+
+	const dispatch = createEventDispatcher();
 
 	if (context) {
 		Object.keys(context).forEach((key) => {
 			setContext(key, context[key]);
 		});
 	}
-	if (onCreate) bind(onCreate)();
-	if (onMountFn) onMount(bind(onMount));
-	if (beforeUpdateFn) beforeUpdate(bind(beforeUpdate));
-	if (afterUpdateFn) afterUpdate(bind(afterUpdate));
-	if (onDestroyFn) onDestroy(bind(onDestroy));
 
-	function bind(callback) {
-		return () => callback({ props: $$restProps });
-	}
+	dispatch('create', { props: $$restProps });
+	onMount(() => dispatch('mount', { props: $$restProps }));
+	beforeUpdate(() => dispatch('before:update', { props: $$restProps }));
+	afterUpdate(() => dispatch('after:update', { props: $$restProps }));
+	onDestroy(() => dispatch('destroy', { props: $$restProps }));
 
 	/** action for rendering fragment content */
 	function fragment(node) {
@@ -58,7 +52,7 @@ Fragments let you group a list of children without adding extra nodes to the DOM
 
 	// lifecyle usage
 	<Fragment
-		onCreate={() => {
+		on:create={() => {
 			setContext('some context key', theValue)
 		}}
 	>

--- a/packages/svelteui-core/src/lib/components/Modal/Modal.styles.ts
+++ b/packages/svelteui-core/src/lib/components/Modal/Modal.styles.ts
@@ -32,7 +32,6 @@ export interface ModalProps extends DefaultProps {
 	centered?: boolean;
 	target?: HTMLElement | string;
 	withinPortal?: boolean;
-	onClose(args?: any): any;
 }
 
 export interface ModalStylesParams {

--- a/packages/svelteui-core/src/lib/components/Modal/Modal.svelte
+++ b/packages/svelteui-core/src/lib/components/Modal/Modal.svelte
@@ -8,7 +8,7 @@
 	import { Box } from '../Box';
 	import { randomID, colorScheme, css } from '$lib/styles';
 	import { lockscroll } from '@svelteuidev/composables';
-	import { onMount } from 'svelte';
+	import { createEventDispatcher, onMount } from 'svelte';
 	import { fade, scale } from 'svelte/transition';
 	import { sineInOut } from 'svelte/easing';
 	import type { ModalProps as $$ModalProps } from './Modal.styles';
@@ -36,10 +36,10 @@
 		trapFocus: $$ModalProps['trapFocus'] = false,
 		centered: $$ModalProps['centered'] = null,
 		target: $$ModalProps['target'] = '#SVELTEUI_PROVIDER',
-		withinPortal: $$ModalProps['withinPortal'] = true,
-		onClose: $$ModalProps['onClose'];
+		withinPortal: $$ModalProps['withinPortal'] = true;
 	export { className as class };
 
+	const dispatch = createEventDispatcher();
 	const castAny = (self: unknown) => self as any;
 	const baseId = randomID(id);
 	const titleId = `${baseId}-title`;
@@ -52,6 +52,10 @@
 			onClose();
 		}
 	};
+
+	function onClose() {
+		dispatch('close');
+	}
 
 	// Temporary, just add zIndex to Portal component
 	const zIndexStyles = css({ zIndex });

--- a/packages/svelteui-core/src/lib/components/Notification/Notification.styles.ts
+++ b/packages/svelteui-core/src/lib/components/Notification/Notification.styles.ts
@@ -14,7 +14,6 @@ export interface NotificationProps extends DefaultProps {
 	withCloseButton?: boolean;
 	closeButtonLabel?: string;
 	closeButtonProps?: CloseButtonProps;
-	onClose?(...args: any[]): any;
 }
 
 export interface NotificationStylesParams {

--- a/packages/svelteui-core/src/lib/components/Notification/Notification.svelte
+++ b/packages/svelteui-core/src/lib/components/Notification/Notification.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { createEventDispatcher } from 'svelte';
 	import useStyles from './Notification.styles';
 	import { Box } from '../Box';
 	import { CloseButton } from '../ActionIcon';
@@ -19,9 +20,14 @@
 		iconProps: $$NotificationProps['iconProps'] = {},
 		withCloseButton: $$NotificationProps['withCloseButton'] = true,
 		closeButtonLabel: $$NotificationProps['closeButtonLabel'] = undefined,
-		closeButtonProps: $$NotificationProps['closeButtonProps'] = {},
-		onClose: $$NotificationProps['onClose'] = () => {};
+		closeButtonProps: $$NotificationProps['closeButtonProps'] = {};
 	export { className as class };
+
+	const dispatch = createEventDispatcher();
+
+	function onClose() {
+		dispatch('close');
+	}
 
 	$: ({ cx, classes } = useStyles({ color, radius }, { override }));
 </script>

--- a/packages/svelteui-demos/src/lib/components/Configurator/Configurator.svelte
+++ b/packages/svelteui-demos/src/lib/components/Configurator/Configurator.svelte
@@ -74,8 +74,8 @@
 		return acc;
 	}
 
-	function onChange(newData) {
-		data = newData;
+	function onChange(event) {
+		data = event.detail;
 	}
 
 	function generateCode(
@@ -212,7 +212,7 @@
 			</div>
 		</div>
 		<div class="controls">
-			<ControlsRenderer value={data} controls={demoControls} {onChange} />
+			<ControlsRenderer value={data} controls={demoControls} on:change={onChange} />
 			<!--			<button {data}> test </button>-->
 			<!--			<button {data} />-->
 			<!--			<button />-->

--- a/packages/svelteui-demos/src/lib/components/Configurator/controls/ControlsRenderer.svelte
+++ b/packages/svelteui-demos/src/lib/components/Configurator/controls/ControlsRenderer.svelte
@@ -1,15 +1,17 @@
 <script lang="ts">
 	/* eslint-disable  @typescript-eslint/no-explicit-any */
+	import { createEventDispatcher } from 'svelte';
 	import { controls as controlsComponents } from './index';
 	import type { DemoControl } from '$lib/types';
 	import { upperFirst, isEnabled } from '../../../utils';
 
 	export let value: Record<string, any> = {};
 	export let controls: DemoControl[];
-	export let onChange: (data) => void;
 
 	// Contain data for all possible controls even for conditional, we want to keep track of all data
 	let data: Record<string, any> = controls.reduce(dataReducer, {});
+
+	const dispatch = createEventDispatcher();
 
 	function dataReducer(acc, { name, initialValue, type, controls }) {
 		acc[name] =
@@ -18,8 +20,6 @@
 				: value[name] ?? controls.reduce(dataReducer, {});
 		return acc;
 	}
-
-	// $: triggerChange(value, data);
 
 	$: controlsData = controls.map((control) => {
 		const { type, label, name, ...props } = control;
@@ -36,17 +36,10 @@
 			hidden: !isEnabled(control, data)
 		};
 	});
-	//
-	// function triggerChange(value, data) {
-	// 	console.log('triggerChange', value, data);
-	// 	if (JSON.stringify(value) !== JSON.stringify(data)) {
-	// 		onChange(data);
-	// 	}
-	// }
 
 	function changeData(name: string, value: any) {
 		data = { ...data, [name]: value };
-		onChange(data);
+		dispatch('change', data);
 	}
 </script>
 
@@ -59,7 +52,6 @@
 				{value}
 				{...props}
 				on:change={onChange}
-				onChange=""
 			/>
 		</div>
 	{/if}

--- a/packages/svelteui-demos/src/lib/demos/core/Fragment/Fragment.demo.context.svelte
+++ b/packages/svelteui-demos/src/lib/demos/core/Fragment/Fragment.demo.context.svelte
@@ -9,7 +9,7 @@
 <\/script>
 
 <Fragment
-    onCreate={() => {
+	on:create={() => {
       setContext('some context key', value)
     }}
 >

--- a/packages/svelteui-demos/src/lib/demos/core/Fragment/Fragment.demo.lifecycle.svelte
+++ b/packages/svelteui-demos/src/lib/demos/core/Fragment/Fragment.demo.lifecycle.svelte
@@ -7,11 +7,11 @@
 
 <Fragment
 	mode="lifecycle"
-	onCreate={() => console.log('Component Created')}
-	onMount={() => console.log('Component Mounted')}
-	beforeUpdate={() => console.log('Component is about to update')}
-	afterUpdate={() => console.log('Component just updated')}
-	onDestroy={() => console.log('Component Destroyed')}
+	on:create={() => console.log('Component Created')}
+	on:mount={() => console.log('Component Mounted')}
+	on:before:update={() => console.log('Component is about to update')}
+	on:after:update={() => console.log('Component just updated')}
+	on:destroy={() => console.log('Component Destroyed')}
 >
 	some content
 </Fragment>`;
@@ -29,11 +29,11 @@
 
 <Fragment
 	mode="lifecycle"
-	onCreate={() => console.log('Component Created')}
-	onMount={() => console.log('Component Mounted')}
-	beforeUpdate={() => console.log('Component is about to update')}
-	afterUpdate={() => console.log('Component just updated')}
-	onDestroy={() => console.log('Component Destroyed')}
+	on:create={() => console.log('Component Created')}
+	on:mount={() => console.log('Component Mounted')}
+	on:before:update={() => console.log('Component is about to update')}
+	on:after:update={() => console.log('Component just updated')}
+	on:destroy={() => console.log('Component Destroyed')}
 >
 	some content
 </Fragment>

--- a/packages/svelteui-prism/src/lib/dist/Prism/Prism.svelte
+++ b/packages/svelteui-prism/src/lib/dist/Prism/Prism.svelte
@@ -1,4 +1,6 @@
-<script lang="ts">
+
+<script lang="ts" data-manual>
+	// option 'data-manual' needed to use Prism with no automatic highlight on import
 	import Prism from 'prismjs';
 	import { onMount } from 'svelte';
 	import { config } from './Prism.config.js';
@@ -266,6 +268,8 @@
 		</ActionIcon>
 	{/if}
 	<pre class={prismClasses} data-line={highlightLines}>
-		{@html prettyCode}
+		<code>
+			{@html prettyCode}
+		</code>
 	</pre>
 </div>


### PR DESCRIPTION
- Changed all components that used prop function to instead dispatch events
- Changed ControlsRenderer and Configurator to also use the dispatch approach

- Fixed problem in Prism where the line numbers and line highlight were not working. This was due to a recent change where the `<code>` tag was removed because Prism highlights automatically on import (which we don't want because it causes all kinds of trouble). The `<code>` tag is necessary for the line highlight so, after exploring the Prism code and its Github, there is a way of setting the Prism to manual (no automatic stuff) by adding `data-manual` to the script tag that imports the Prism script. Now it works fine :+1: 

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [ ] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [ ] This message body should clearly illustrate what problems it solves.

### Tests

- [ ] Run the tests with `npm test` and lint the project with `npm run lint` or just run `npm run repo:prepush` and check to see if it's passing.
