### PR TITLE
[docs] update old composables docs to use demos

### DIFF
--- a/docs/src/pages/composables/use-click-outside.md
+++ b/docs/src/pages/composables/use-click-outside.md
@@ -10,33 +10,8 @@ source: 'svelteui-composables/src/lib/actions/use-click-outside/use-click-outsid
 ---
 
 <script lang='ts'>
-    import { Button } from '@svelteuidev/core';
-	import { clickoutside } from '@svelteuidev/composables';
-    import { Heading, Preview } from 'components'
-
-	let open = true;
-
-    const code = `
-    <script>
-        import { Button } from '@svelteuidev/core';
-        import { clickoutside } from '@svelteuidev/composables';
-
-        let open = true;
-    <\/script>
-
-    <div use:clickoutside={{ enabled: open, callback: () => open = false }}>
-        <Button on:click={() => open = true}>Open Modal<\/Button>
-        {#if open}
-            <div style="border: 2px solid gray; padding: 2rem;">
-                This is a modal, click anywhere to close
-            <\/div>
-        {:else if !open}
-            <div>
-                There is no modal
-            <\/div>
-        {\/if}
-    <\/div>
-    `
+    import { Demo, ComposableDemos } from '@svelteuidev/demos';
+    import { Heading } from 'components';
 </script>
 
 <Heading />
@@ -45,21 +20,7 @@ source: 'svelteui-composables/src/lib/actions/use-click-outside/use-click-outsid
 
 With the `use-click-outside` action, a callback function will be fired whenever the user clicks outside of the dom node the action is applied to.
 
-<Preview cols={1} {code}>
-
-<div use:clickoutside={{ enabled: open, callback: () => open = false }}>
-<Button on:click={() => open = true}>Open Modal</Button>
-{#if open}
-<div style="border: 2px solid gray; padding: 2rem;">
-This is a modal, click anywhere to close
-</div>
-{:else if !open}
-<div>
-There is no modal
-</div>
-{/if}
-</div>
-</Preview>
+<Demo demo={ComposableDemos.useClickOutsideDemo.usage} />
 
 ## Params
 

--- a/docs/src/pages/composables/use-clipboard.md
+++ b/docs/src/pages/composables/use-clipboard.md
@@ -10,39 +10,8 @@ source: 'svelteui-composables/src/lib/actions/use-clipboard/use-clipboard.ts'
 ---
 
 <script lang='ts'>
-    import { Button } from '@svelteuidev/core';
-	import { clipboard } from '@svelteuidev/composables';
-    import { Heading, Preview } from 'components'
-
-	let textToCopy = 'This message was copied';
-	let copied = false;
-    let onCopy = () => {
-        copied = true;
-        setTimeout(function () {
-            copied = false;
-        }, 1000);
-    }
-
-    const code = `
-    <script>
-        import { Button } from '@svelteuidev/core';
-        import { clipboard } from '@svelteuidev/composables';
-
-        let textToCopy = 'This message was copied';
-        let copied = false;
-        setTimeout(function () {
-            copied = false;
-        }, 1000);
-    <\/script>
-
-    <Button
-        use={[[clipboard, textToCopy]]}
-        on:useclipboard={onCopy}
-        color={copied ? 'green' : 'blue'}
-    >
-        {copied ? 'copied' : 'Click me to copy text'}
-    <\/Button>
-    `
+    import { Demo, ComposableDemos } from '@svelteuidev/demos';
+    import { Heading } from 'components';
 </script>
 
 <Heading />
@@ -51,14 +20,7 @@ source: 'svelteui-composables/src/lib/actions/use-clipboard/use-clipboard.ts'
 
 With the use-clipboard action, text passed into the text param will be copied to the users clipboard.
 
-<Preview cols={1} {code}>
-<Button
-use={[[clipboard, textToCopy]]}
-on:useclipboard={onCopy}
-color={copied ? 'green' : 'blue'} >
-{copied ? 'copied' : 'Click me to copy text'}
-</Button>
-</Preview>
+<Demo demo={ComposableDemos.useClipboardDemo.usage} />
 
 ## Params
 

--- a/docs/src/pages/composables/use-css-variable.md
+++ b/docs/src/pages/composables/use-css-variable.md
@@ -10,39 +10,8 @@ source: 'svelteui-composables/src/lib/actions/use-css-variable/use-css-variable.
 ---
 
 <script lang='ts'>
-    import { Button } from '@svelteuidev/core';
-	import { cssvariable } from '@svelteuidev/composables';
-    import { Heading, Preview } from 'components'
-
-	let isRed = true;
-
-    const code = `
-    <script>
-        import { Button } from '@svelteuidev/core';
-        import { cssvariable } from '@svelteuidev/composables';
-
-        let isRed = true;
-
-        $: styleVars = {
-            titleColor: isRed ? 'red' : 'blue'
-        };
-    <\/script>
-
-    <div use:cssvariable={styleVars}>
-        <!-- anything here will have access to var(--titleColor) -->
-        <p>This text is normal<\/p>
-        <p class="example">This text is using the variable<\/p>
-    <\/div>
-    <Button on:click={() => (isRed = !isRed)}>Click to switch colors<\/Button>
-
-    <style>
-        .example-text {
-            color: var(--titleColor);
-        }
-    <\/style>
-    `;
-
-    $: styleVars = { titleColor: isRed ? 'red' : 'blue' };
+    import { Demo, ComposableDemos } from '@svelteuidev/demos';
+    import { Heading } from 'components';
 </script>
 
 <Heading />
@@ -51,20 +20,7 @@ source: 'svelteui-composables/src/lib/actions/use-css-variable/use-css-variable.
 
 With the `use-css-variable` action, an object of properties will be treated as css custom variables. By defining this object inside of a `$: ` reactive block, `use-css-variable` can update those css properties on the fly whenever some of its values change.
 
-<Preview cols={1} {code}>
-
-<div use:cssvariable={styleVars}>
-<p>This text is normal</p>
-<p class="example-text">This text is using the variable</p>
-</div>
-<Button on:click={() => (isRed = !isRed)}>Click to switch colors</Button>
-</Preview>
-
-<style>
-    .example-text {
-        color: var(--titleColor);
-    }
-</style>
+<Demo demo={ComposableDemos.useCssVariableDemo.usage} />
 
 ## Params
 

--- a/docs/src/pages/composables/use-download.md
+++ b/docs/src/pages/composables/use-download.md
@@ -10,53 +10,19 @@ source: 'svelteui-composables/src/lib/actions/use-download/use-download.ts'
 ---
 
 <script>
-    import { Button, Text } from '@svelteuidev/core';
-	import { download } from '@svelteuidev/composables';
-    import { Heading, Preview } from 'components'
-    import { fade } from 'svelte/transition'
-
-    const file = new Blob([])
-    let downloaded = false
-
-    const code = `
-    <script>
-        import { Button } from '@svelteuidev/core';
-        import { download } from '@svelteuidev/composables';
-
-        const file = new Blob([])
-    <\/script>
-
-    <Button 
-        variant='outline'
-        use={[[download, { blob: file, filename: "test.txt" }]]}
-        on:usedownload={() => console.log('File Downloaded')}
-    >
-        Download File
-    <\/Button>
-    `;
+    import { Demo, ComposableDemos } from '@svelteuidev/demos';
+    import { Heading } from 'components';
 </script>
 
 <Heading />
 
 ## Usage
 
-> use-download is currently bugged
+> use-download example is currently not working here due to a limitation in the docs routing, it works with Svelte + SvelteKit
 
 With the `use-download` action, a download will occur with a given Blob object as a file with the given filename. It takes an argument of options, which is an object that has two properties. The blob option is a file-like object of immutable, raw data. The filename option is the filename that will be given to the Blob.
 
-<Preview cols={1} {code}>
-<Button
-variant='outline'
-use={[[download, { blob: file, filename: "test.txt" }]]}
-on:usedownload={() => downloaded = true} >
-Download File
-</Button>
-{#if downloaded}
-<span transition:fade>
-<Text>File downloaded!</Text>
-</span>
-{/if}
-</Preview>
+<Demo demo={ComposableDemos.useDownloadDemo.usage} />
 
 ## Params
 

--- a/docs/src/pages/composables/use-eye-dropper.md
+++ b/docs/src/pages/composables/use-eye-dropper.md
@@ -10,8 +10,8 @@ source: 'svelteui-composables/src/lib/utilities/use-eye-dropper/use-eye-dropper.
 ---
 
 <script lang='ts'>
-    import { Demo, ComposableDemos } from "@svelteuidev/demos";
-    import { Heading} from 'components'
+    import { Demo, ComposableDemos } from '@svelteuidev/demos';
+    import { Heading } from 'components';
 </script>
 
 <Heading />

--- a/docs/src/pages/composables/use-focus.md
+++ b/docs/src/pages/composables/use-focus.md
@@ -10,36 +10,8 @@ source: 'svelteui-composables/src/lib/actions/use-focus/use-focus.ts'
 ---
 
 <script lang='ts'>
-    import { Button, Input, InputWrapper } from '@svelteuidev/core';
-	import { focus } from '@svelteuidev/composables';
-    import { Heading, Preview } from 'components'
-
-	let name = 'world';
-    let editing = false;
-    function toggleEdit() {
-        editing = !editing;
-    }
-
-    const code = `
-    <script>
-        import { Button, Input, InputWrapper } from '@svelteuidev/core';
-        import { focus } from '@svelteuidev/composables';
-
-        let name = 'world';
-        let editing = false;
-        function toggleEdit() {
-            editing = !editing;
-        }
-    <\/script>
-
-    <p>Name: {name}<\/p>
-    {#if editing}
-        <InputWrapper label='Name'>
-            <Input use={[[focus]]} bind:value={name} \/>
-        <\/InputWrapper>
-    {\/if}
-    <Button on:click={toggleEdit}>{editing ? 'Confirm' : 'Edit'}<\/Button>
-    `
+    import { Demo, ComposableDemos } from '@svelteuidev/demos';
+    import { Heading } from 'components';
 </script>
 
 <Heading />
@@ -48,16 +20,7 @@ source: 'svelteui-composables/src/lib/actions/use-focus/use-focus.ts'
 
 The `use-focus` action is the simplest action out of all. It has a single purpose, and that is to give immediate focus to an element once it is mounted into the DOM. Only "focusable" elements should use this action. Type errors will appear if this is not the case.
 
-<Preview cols={1} {code}>
-
-<p>Name: {name}</p>
-{#if editing}
-<InputWrapper label='Name'>
-<Input use={[[focus]]} bind:value={name} />
-</InputWrapper>
-{/if}
-<Button on:click={toggleEdit}>{editing ? 'Confirm' : 'Edit'}</Button>
-</Preview>
+<Demo demo={ComposableDemos.useFocusDemo.usage} />
 
 ## Definition
 

--- a/docs/src/pages/composables/use-lazy.md
+++ b/docs/src/pages/composables/use-lazy.md
@@ -10,24 +10,8 @@ source: 'svelteui-composables/src/lib/actions/use-lazy/use-lazy.ts'
 ---
 
 <script>
-    import { Button } from '@svelteuidev/core';
-	import { lazy } from '@svelteuidev/composables';
-    import { Heading, Preview } from 'components'
-
-    const code = `
-    <script>
-        import { lazy } from '@svelteuidev/composables'
-    <\/script>
-    
-    <div style='height: 300px;'>
-        {#each [...Array(15).keys()] as _}
-            <p>
-                Lorem ipsum dolor sit amet consectetur adipisicing elit. Aspernatur obcaecati ex totam laboriosam, culpa ipsa quis nostrum odio dolore aut eos numquam ratione quam maiores voluptates quas eius labore error?
-            <\/p>
-        {\/each}
-        <img use:lazy={{src: "https://images.unsplash.com/photo-1584441111639-2fe3005b4378"}} alt="" \/>
-    <\/div>
-    `
+    import { Demo, ComposableDemos } from '@svelteuidev/demos';
+    import { Heading } from 'components';
 </script>
 
 <Heading />
@@ -36,15 +20,7 @@ source: 'svelteui-composables/src/lib/actions/use-lazy/use-lazy.ts'
 
 With the `use-lazy` action, you can set attributes on an element when it is visible in the viewport.
 
-<Preview override={{height: '300px', overflow: 'scroll', '#code-button': {position: 'sticky', top: '90%', right: 0}}} cols={1} {code}>
-{#each [...Array(15).keys()] as i}
-
-<p>
-Lorem ipsum dolor sit amet consectetur adipisicing elit. Aspernatur obcaecati ex totam laboriosam, culpa ipsa quis nostrum odio dolore aut eos numquam ratione quam maiores voluptates quas eius labore error?
-</p>
-{/each}
-<img use:lazy={{src: "https://images.unsplash.com/photo-1584441111639-2fe3005b4378"}} alt="" />
-</Preview>
+<Demo demo={ComposableDemos.useLazyDemo.usage} />
 
 ## Params
 

--- a/docs/src/pages/composables/use-long-press.md
+++ b/docs/src/pages/composables/use-long-press.md
@@ -10,37 +10,8 @@ source: 'svelteui-composables/src/lib/actions/use-long-press/use-long-press.ts'
 ---
 
 <script>
-    import { Button } from '@svelteuidev/core';
-    import { longpress } from '@svelteuidev/composables';
-    import { Heading, Preview } from 'components';
-
-    let pressed = false;
-	let duration = 2000;
-
-    const code = `
-    <script>
-        import { Button } from '@svelteuidev/core';
-        import { longpress } from '@svelteuidev/composables'
-
-        let pressed = false;
-	    let duration = 2000;
-    <\/script>
-    
-    <input type=range bind:value={duration} max={2000} step={100} \/>
-    {duration}ms
-
-    <Button 
-        use={[[longpress, duration]]}
-        on:longpress="{() => pressed = true}"
-        on:mouseenter="{() => pressed = false}"
-    >
-        press and hold
-    <\/Button>
-
-    {#if pressed}
-        <p>congratulations, you pressed and held for {duration} ms<\/p>
-    {\/if}
-    `
+    import { Demo, ComposableDemos } from '@svelteuidev/demos';
+    import { Heading } from 'components';
 </script>
 
 <Heading />
@@ -49,27 +20,7 @@ source: 'svelteui-composables/src/lib/actions/use-long-press/use-long-press.ts'
 
 With the `use-long-press` action, a `long press` event is created when `mousedown` or `touchstart` is above the `duration` passed in, in milliseconds.
 
-<Preview cols={1} {code}>
-<input type=range bind:value={duration} max={2000} step={100} />
-{duration}ms
-
-<Button
-use={[[longpress, duration]]}
-on:uselongpress={() => pressed = true}
-on:mouseenter={() => pressed = false}
-on:touchstart={() => pressed = false}
-
->
-
-    press and hold
-
-</Button>
-
-{#if pressed}
-
-<p>congratulations, you pressed and held for {duration} ms</p>
-{/if}
-</Preview>
+<Demo demo={ComposableDemos.useLongPressDemo.usage} />
 
 ## Params
 
@@ -88,8 +39,8 @@ on:uselongpress?: (callback: (any) => unknown) => void;
 ## Definition
 
 ```ts
-export function lazy(
+export function longpress(
 	node: HTMLElement,
-	attributes: Record<string, number | string>
+	duration: number
 ): ReturnType<Action>;
 ```

--- a/docs/src/pages/composables/use-page-leave.md
+++ b/docs/src/pages/composables/use-page-leave.md
@@ -10,20 +10,8 @@ source: 'svelteui-composables/src/lib/actions/use-page-leave/use-page-leave.ts'
 ---
 
 <script lang='ts'>
-	import { pageleave } from '@svelteuidev/composables';
-    import { Heading, Preview } from 'components'
-
-    const code = `
-    <script>
-        import { pageleave } from '@svelteuidev/composables';
-
-        $: count = 0;
-    <\/script>
-
-    <div use:pageleave={() => count++}>Move the mouse off the page to see the counter go up: {count}<\/div>
-    `;
-
-    $: count = 0;
+	import { Demo, ComposableDemos } from '@svelteuidev/demos';
+    import { Heading } from 'components';
 </script>
 
 <Heading />
@@ -32,10 +20,7 @@ source: 'svelteui-composables/src/lib/actions/use-page-leave/use-page-leave.ts'
 
 The `use-page-leave` action calls given function when mouse leaves the page.
 
-<Preview cols={1} {code}>
-
-<div use:pageleave={() => count++}>Move the mouse off the page to see the counter go up: {count}</div>
-</Preview>
+<Demo demo={ComposableDemos.usePageLeaveDemo.usage} />
 
 ## Params
 

--- a/docs/src/pages/composables/use-persistent-tab.md
+++ b/docs/src/pages/composables/use-persistent-tab.md
@@ -10,27 +10,8 @@ source: 'svelteui-composables/src/lib/actions/use-persistent-tab/use-persistent-
 ---
 
 <script>
-    import { Button } from '@svelteuidev/core';
-    import { persistenttab } from '@svelteuidev/composables';
-    import { Heading, Preview } from 'components';
-
-    let isNotClosable = false;
-
-    const code = `
-    <script>
-        import { persistenttab } from '@svelteuidev/composables'
-
-        let isNotClosable = false;
-    <\/script>
-    
-    <button on:click={() => isNotClosable = !isNotClosable}>
-       {isNotClosable ? "Can't close tab" : 'Can close tab'}
-    <\/button>
-
-    <div use:persistenttab={isNotClosable}>
-        Something important that the user wouldn't want to lose to a page refresh or close
-    <\/div>
-    `
+    import { Demo, ComposableDemos } from '@svelteuidev/demos';
+    import { Heading } from 'components';
 </script>
 
 <Heading />
@@ -39,16 +20,7 @@ source: 'svelteui-composables/src/lib/actions/use-persistent-tab/use-persistent-
 
 With the `use-persistent-tab` action, you can prevent current tab from being closed by user. A common use case for this is when a user is filling out a form, and you don't want them to lose their data/progress.
 
-<Preview cols={1} {code}>
-<Button ripple on:click={() => isNotClosable = !isNotClosable}>
-{isNotClosable ? "Can't close tab" : 'Can close tab'}
-</Button>
-
-    <div use:persistenttab={isNotClosable}>
-        Something important that the user wouldn't want to lose to a page refresh or close
-    </div>
-
-</Preview>
+<Demo demo={ComposableDemos.usePersistentTabDemo.usage} />
 
 ## Params
 

--- a/docs/src/pages/composables/use-portal.md
+++ b/docs/src/pages/composables/use-portal.md
@@ -10,33 +10,8 @@ source: 'svelteui-composables/src/lib/actions/use-portal/use-portal.ts'
 ---
 
 <script>
-    import { portal } from '@svelteuidev/composables';
-    import { Box, Button } from '@svelteuidev/core'
-    import { Heading, Preview } from 'components';
-
-    let magic = false
-
-    const code = `
-    <script>
-        import { portal } from '@svelteuidev/composables';
-        import { Box, Button } from '@svelteuidev/core'
-    <\/script>
-    
-    {#if magic}
-        <div>
-            Look at the top of the page
-        <\/div>
-    {\/if}
-    <div>
-        <Box 
-            use={[[portal, magic ? 'h1' : null]]}
-            css={{bc: 'white', border: '1px solid black', br: '$md', padding: '$md'}} 
-        >
-            I'm being rendered {magic ? 'outside' : 'inside'} of the preview
-        <\/Box>
-    <\/div>
-    <Button on:click={() => magic = !magic}>Click me to see the magic<\/Button>
-    `
+    import { Demo, ComposableDemos } from '@svelteuidev/demos';
+    import { Heading } from 'components';
 </script>
 
 <Heading />
@@ -45,22 +20,7 @@ source: 'svelteui-composables/src/lib/actions/use-portal/use-portal.ts'
 
 Render any component or element at the end of document.body or at given element. Modal and Drawer components use portal by default. Use the `portal` action to render a component or element outside of it's parent. The portal action takes one argument (target):
 
-<Preview cols={1} {code}>
-{#if magic}
-
-<div>
-Look at the top of the page
-</div>
-{/if}
-<div>
-<Box
-use={[[portal, magic ? 'h1' : null]]}
-css={{bc: 'white', border: '1px solid black', br: '$md', padding: '$md'}} >
-I'm being rendered {magic ? 'outside' : 'inside'} of the preview
-</Box>
-</div>
-<Button on:click={() => magic = true}>{magic ? 'Refresh the page to see again' : 'Click me to see the magic'}</Button>
-</Preview>
+<Demo demo={ComposableDemos.usePortalDemo.usage} />
 
 You can specify a dom node where portal will be rendered by passing target argument. If you don't specify the target, it will be appended to the document.body for each action instance. Target can be a HTMLElement <code>{'use:portal={document.body}'}</code> or a css selector <code>{'use:portal={"#svelteui"}'}</code> that points to an already existing element.
 

--- a/docs/src/pages/composables/use-tab-leave.md
+++ b/docs/src/pages/composables/use-tab-leave.md
@@ -10,20 +10,8 @@ source: 'svelteui-composables/src/lib/actions/use-tab-leave/use-tab-leave.ts'
 ---
 
 <script lang='ts'>
-	import { tableave } from '@svelteuidev/composables';
-    import { Heading, Preview } from 'components'
-
-    const code = `
-    <script>
-        import { tableave } from '@svelteuidev/composables';
-
-        $: count = 0;
-    <\/script>
-
-    <div use:tableave={() => count++}>Switch the tab to see the counter go up: {count}<\/div>
-    `;
-
-    $: count = 0;
+	import { Demo, ComposableDemos } from '@svelteuidev/demos';
+    import { Heading } from 'components';
 </script>
 
 <Heading />
@@ -32,10 +20,7 @@ source: 'svelteui-composables/src/lib/actions/use-tab-leave/use-tab-leave.ts'
 
 The `use-tab-leave` action calls given function when the current tab is switched.
 
-<Preview cols={1} {code}>
-
-<div use:tableave={() => count++}>Switch the tab to see the counter go up: {count}</div>
-</Preview>
+<Demo demo={ComposableDemos.useTabLeaveDemo.usage} />
 
 ## Params
 

--- a/packages/svelteui-composables/src/lib/actions/use-long-press/use-long-press.ts
+++ b/packages/svelteui-composables/src/lib/actions/use-long-press/use-long-press.ts
@@ -16,7 +16,7 @@ export function longpress(node: HTMLElement, duration: number): ReturnType<Actio
 
 	function handlePress() {
 		timer = window.setTimeout(() => {
-			node.dispatchEvent(new CustomEvent('uselongpress'));
+			node.dispatchEvent(new CustomEvent('longpress'));
 		}, duration);
 	}
 

--- a/packages/svelteui-dates/src/lib/components/CalendarBase/CalendarHeader/CalendarHeader.svelte
+++ b/packages/svelteui-dates/src/lib/components/CalendarBase/CalendarHeader/CalendarHeader.svelte
@@ -1,8 +1,5 @@
 <script lang="ts">
-    import {
-  ActionIcon,
-  UnstyledButton,
-} from '@svelteuidev/core';
+import { ActionIcon, UnstyledButton } from '@svelteuidev/core';
 import useStyles, { type CalendarHeaderProps as $$CalendarHeaderProps } from "./CalendarHeader.styles";
 import SelectChevronIcon from "./SelectChevronIcon.svelte";
 import ArrowIcon from './ArrowIcon.svelte'

--- a/packages/svelteui-demos/src/lib/demos/composables/actions/index.ts
+++ b/packages/svelteui-demos/src/lib/demos/composables/actions/index.ts
@@ -1,4 +1,14 @@
-export * as useLazyDemo from './use-lazy';
+export * as useClickOutsideDemo from './use-click-outside';
+export * as useClipboardDemo from './use-clipboard';
+export * as useCssVariableDemo from './use-css-variable';
+export * as useDownloadDemo from './use-download';
+export * as useFocusDemo from './use-focus';
 export * as useHotKeyDemo from './use-hot-key';
-export * as useLockScrollDemo from './use-lock-scroll';
 export * as useIoDemo from './use-io';
+export * as useLazyDemo from './use-lazy';
+export * as useLockScrollDemo from './use-lock-scroll';
+export * as useLongPressDemo from './use-long-press';
+export * as usePageLeaveDemo from './use-page-leave';
+export * as usePersistentTabDemo from './use-persistent-tab';
+export * as usePortalDemo from './use-portal';
+export * as useTabLeaveDemo from './use-tab-leave';

--- a/packages/svelteui-demos/src/lib/demos/composables/actions/use-click-outside/index.ts
+++ b/packages/svelteui-demos/src/lib/demos/composables/actions/use-click-outside/index.ts
@@ -1,0 +1,1 @@
+export * as usage from './usage.svelte';

--- a/packages/svelteui-demos/src/lib/demos/composables/actions/use-click-outside/usage.svelte
+++ b/packages/svelteui-demos/src/lib/demos/composables/actions/use-click-outside/usage.svelte
@@ -1,0 +1,64 @@
+<script lang="ts" context="module">
+	import type { CodeDemoType, CodeDemoConfiguration } from '$lib/types';
+
+	const code = `
+<script>
+    import { Button, Paper } from '@svelteuidev/core';
+    import { clickoutside } from '@svelteuidev/composables';
+
+    let open = true;
+<\/script>
+
+<div use:clickoutside={{ enabled: open, callback: () => open = false }}>
+    <Button on:click={() => open = true}>Open Modal</Button>
+    {#if open}
+        <Paper shadow='sm'>
+            This is a modal, click anywhere to close
+        </Paper>
+    {/if}
+</div>`;
+
+	export const type: CodeDemoType['type'] = 'demo';
+
+	export const configuration: CodeDemoConfiguration = {
+		code
+	};
+</script>
+
+<script>
+	import { Button, Center, Group, Paper, useSvelteUITheme } from '@svelteuidev/core';
+	import { clickoutside } from '@svelteuidev/composables';
+
+    let open = false;
+    let theme = useSvelteUITheme();
+</script>
+
+<Center>
+    <div style='position: relative;' use:clickoutside={{ enabled: open, callback: () => open = false }}>
+        <Group position='center'>
+            <Button on:click={() => open = true}>Open Modal</Button>
+        </Group>
+        {#if open}
+            <Paper
+                shadow='sm'
+                override={{
+                    zIndex: 1,
+                    width: 300,
+                    height: 60,
+                    position: 'absolute',
+                    top: 0,
+                    left: 'calc(50% - 150px)',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    backgroundColor: theme.colors.white.value,
+                    darkMode: {
+                        color: theme.fn.themeColor('dark', 6)
+                    }
+                }}
+            >
+                This is a modal, click anywhere to close
+            </Paper>
+        {/if}
+    </div>
+</Center>

--- a/packages/svelteui-demos/src/lib/demos/composables/actions/use-clipboard/index.ts
+++ b/packages/svelteui-demos/src/lib/demos/composables/actions/use-clipboard/index.ts
@@ -1,0 +1,1 @@
+export * as usage from './usage.svelte';

--- a/packages/svelteui-demos/src/lib/demos/composables/actions/use-clipboard/usage.svelte
+++ b/packages/svelteui-demos/src/lib/demos/composables/actions/use-clipboard/usage.svelte
@@ -1,0 +1,56 @@
+<script lang="ts" context="module">
+	import type { CodeDemoType, CodeDemoConfiguration } from '$lib/types';
+
+	const code = `
+<script>
+    import { Button } from '@svelteuidev/core';
+	import { clipboard } from '@svelteuidev/composables';
+
+    let textToCopy = 'This message was copied';
+    let copied = false;
+    let onCopy = () => {
+        copied = true;
+        setTimeout(function () {
+            copied = false;
+        }, 1000);
+    }
+<\/script>
+
+<Button
+    use={[[clipboard, textToCopy]]}
+    on:useclipboard={onCopy}
+    color={copied ? 'green' : 'blue'}
+>
+    {copied ? 'copied' : 'Click me to copy text'}
+</Button>`;
+
+	export const type: CodeDemoType['type'] = 'demo';
+
+	export const configuration: CodeDemoConfiguration = {
+		code
+	};
+</script>
+
+<script>
+	import { Button, Center } from '@svelteuidev/core';
+	import { clipboard } from '@svelteuidev/composables';
+
+    let textToCopy = 'This message was copied';
+    let copied = false;
+    let onCopy = () => {
+        copied = true;
+        setTimeout(function () {
+            copied = false;
+        }, 1000);
+    }
+</script>
+
+<Center>
+    <Button
+        use={[[clipboard, textToCopy]]}
+        on:useclipboard={onCopy}
+        color={copied ? 'green' : 'blue'}
+    >
+        {copied ? 'Copied' : 'Click me to copy text'}
+    </Button>
+</Center>

--- a/packages/svelteui-demos/src/lib/demos/composables/actions/use-css-variable/index.ts
+++ b/packages/svelteui-demos/src/lib/demos/composables/actions/use-css-variable/index.ts
@@ -1,0 +1,1 @@
+export * as usage from './usage.svelte';

--- a/packages/svelteui-demos/src/lib/demos/composables/actions/use-css-variable/usage.svelte
+++ b/packages/svelteui-demos/src/lib/demos/composables/actions/use-css-variable/usage.svelte
@@ -1,0 +1,58 @@
+<script lang="ts" context="module">
+	import type { CodeDemoType, CodeDemoConfiguration } from '$lib/types';
+
+	const code = `
+<script>
+    import { Button } from '@svelteuidev/core';
+    import { cssvariable } from '@svelteuidev/composables';
+
+    let isRed = true;
+    $: styleVars = {
+        titleColor: isRed ? 'red' : 'blue'
+    };
+<\/script>
+
+<div use:cssvariable={styleVars}>
+    <!-- anything here will have access to var(--titleColor) -->
+    <p>This text is normal</p>
+    <p class="example">This text is using the variable</p>
+</div>
+<Button on:click={() => (isRed = !isRed)}>Click to switch colors</Button>
+
+<style>
+    .example {
+        color: var(--titleColor);
+    }
+</style>`;
+
+	export const type: CodeDemoType['type'] = 'demo';
+
+	export const configuration: CodeDemoConfiguration = {
+		code
+	};
+</script>
+
+<script>
+	import { Button, Stack } from '@svelteuidev/core';
+	import { cssvariable } from '@svelteuidev/composables';
+
+    let isRed = true;
+    $: styleVars = {
+        titleColor: isRed ? 'red' : 'blue'
+    };
+</script>
+
+<Stack align='center'>
+    <div use:cssvariable={styleVars}>
+        <!-- anything here will have access to var(--titleColor) -->
+        <p>This text is normal</p>
+        <p class="example">This text is using the variable</p>
+    </div>
+    <Button on:click={() => (isRed = !isRed)}>Click to switch colors</Button>
+</Stack>
+
+<style>
+    .example {
+        color: var(--titleColor);
+    }
+</style>

--- a/packages/svelteui-demos/src/lib/demos/composables/actions/use-download/index.ts
+++ b/packages/svelteui-demos/src/lib/demos/composables/actions/use-download/index.ts
@@ -1,0 +1,1 @@
+export * as usage from './usage.svelte';

--- a/packages/svelteui-demos/src/lib/demos/composables/actions/use-download/usage.svelte
+++ b/packages/svelteui-demos/src/lib/demos/composables/actions/use-download/usage.svelte
@@ -1,0 +1,50 @@
+<script lang="ts" context="module">
+	import type { CodeDemoType, CodeDemoConfiguration } from '$lib/types';
+
+	const code = `
+<script>
+    import { onMount } from 'svelte';
+    import { Button } from '@svelteuidev/core';
+    import { download } from '@svelteuidev/composables';
+
+    let file;
+    onMount(() => {
+        file = new Blob([JSON.stringify({ hello: 'world' })], { type: 'application/json' })
+    });
+<\/script>
+
+<Button 
+    variant='outline'
+    use={[[download, { blob: file, filename: "test.txt" }]]}
+    on:usedownload={() => console.log('File Downloaded')}
+>
+    Download File
+</Button>`;
+
+	export const type: CodeDemoType['type'] = 'demo';
+
+	export const configuration: CodeDemoConfiguration = {
+		code
+	};
+</script>
+
+<script>
+	import { onMount } from 'svelte';
+	import { Button, Center } from '@svelteuidev/core';
+	import { download } from '@svelteuidev/composables';
+
+    let file;
+    onMount(() => {
+        file = new Blob([JSON.stringify({ hello: 'world' })], { type: 'application/json' })
+    });
+</script>
+
+<Center>
+    <Button 
+        variant='outline'
+        use={[[download, { blob: file, filename: "hello.txt" }]]}
+        on:usedownload={() => console.log('File Downloaded')}
+    >
+        Download File
+    </Button>
+</Center>

--- a/packages/svelteui-demos/src/lib/demos/composables/actions/use-focus/index.ts
+++ b/packages/svelteui-demos/src/lib/demos/composables/actions/use-focus/index.ts
@@ -1,0 +1,1 @@
+export * as usage from './usage.svelte';

--- a/packages/svelteui-demos/src/lib/demos/composables/actions/use-focus/usage.svelte
+++ b/packages/svelteui-demos/src/lib/demos/composables/actions/use-focus/usage.svelte
@@ -1,0 +1,50 @@
+<script lang="ts" context="module">
+	import type { CodeDemoType, CodeDemoConfiguration } from '$lib/types';
+
+	const code = `
+<script>
+    import { Button, Input, InputWrapper } from '@svelteuidev/core';
+    import { focus } from '@svelteuidev/composables';
+
+    let name = 'world';
+    let editing = false;
+    function toggleEdit() {
+        editing = !editing;
+    }
+<\/script>
+
+<p>Name: {name}</p>
+{#if editing}
+    <InputWrapper label='Name'>
+        <Input use={[[focus]]} bind:value={name} />
+    </InputWrapper>
+{/if}
+<Button on:click={toggleEdit}>{editing ? 'Confirm' : 'Edit'}</Button>`;
+
+	export const type: CodeDemoType['type'] = 'demo';
+
+	export const configuration: CodeDemoConfiguration = {
+		code
+	};
+</script>
+
+<script>
+	import { Button, Input, InputWrapper, Stack } from '@svelteuidev/core';
+	import { focus } from '@svelteuidev/composables';
+
+    let name = 'world';
+    let editing = false;
+    function toggleEdit() {
+        editing = !editing;
+    }
+</script>
+
+<Stack align='center'>
+    <p>Name: {name}</p>
+    {#if editing}
+        <InputWrapper label='Name'>
+            <Input use={[[focus]]} bind:value={name} />
+        </InputWrapper>
+    {/if}
+    <Button on:click={toggleEdit}>{editing ? 'Confirm' : 'Edit'}</Button>
+</Stack>

--- a/packages/svelteui-demos/src/lib/demos/composables/actions/use-lazy/usage.svelte
+++ b/packages/svelteui-demos/src/lib/demos/composables/actions/use-lazy/usage.svelte
@@ -2,7 +2,16 @@
 	import type { CodeDemoType, CodeDemoConfiguration } from '$lib/types';
 
 	const code = `
-`;
+<script>
+    import { lazy } from '@svelteuidev/composables';
+<\/script>
+
+{#each [...Array(15).keys()] as i}
+	<p>
+		Lorem ipsum dolor sit amet consectetur adipisicing elit. Aspernatur obcaecati ex totam laboriosam, culpa ipsa quis nostrum odio dolore aut eos numquam ratione quam maiores voluptates quas eius labore error?
+	</p>
+{/each}
+<img use:lazy={{src: "https://images.unsplash.com/photo-1584441111639-2fe3005b4378"}} alt="" />`;
 
 	export const type: CodeDemoType['type'] = 'demo';
 
@@ -12,7 +21,15 @@
 </script>
 
 <script>
+	import { Stack } from '@svelteuidev/core';
 	import { lazy } from '@svelteuidev/composables';
 </script>
 
-<div>Demo Here</div>
+<Stack override={{ height: '300px', overflow: 'scroll', padding: '1rem' }}>
+    {#each [...Array(15).keys()] as i}
+	<p>
+		Lorem ipsum dolor sit amet consectetur adipisicing elit. Aspernatur obcaecati ex totam laboriosam, culpa ipsa quis nostrum odio dolore aut eos numquam ratione quam maiores voluptates quas eius labore error?
+	</p>
+	{/each}
+	<img use:lazy={{src: "https://images.unsplash.com/photo-1584441111639-2fe3005b4378"}} alt="" />
+</Stack>

--- a/packages/svelteui-demos/src/lib/demos/composables/actions/use-long-press/index.ts
+++ b/packages/svelteui-demos/src/lib/demos/composables/actions/use-long-press/index.ts
@@ -1,0 +1,1 @@
+export * as usage from './usage.svelte';

--- a/packages/svelteui-demos/src/lib/demos/composables/actions/use-long-press/usage.svelte
+++ b/packages/svelteui-demos/src/lib/demos/composables/actions/use-long-press/usage.svelte
@@ -1,0 +1,62 @@
+<script lang="ts" context="module">
+	import type { CodeDemoType, CodeDemoConfiguration } from '$lib/types';
+
+	const code = `
+<script>
+    import { Button } from '@svelteuidev/core';
+    import { longpress } from '@svelteuidev/composables';
+
+    let pressed = false;
+	let duration = 2000;
+<\/script>
+
+<div>
+    <input type=range bind:value={duration} max={2000} step={100} />
+    {duration}ms
+</div>
+
+<Button 
+    use={[[longpress, duration]]}
+    on:longpress="{() => pressed = true}"
+    on:mouseenter="{() => pressed = false}"
+>
+    press and hold
+</Button>
+
+{#if pressed}
+    <p>congratulations, you pressed and held for {duration} ms</p>
+{/if}`;
+
+	export const type: CodeDemoType['type'] = 'demo';
+
+	export const configuration: CodeDemoConfiguration = {
+		code
+	};
+</script>
+
+<script>
+	import { Button, Stack } from '@svelteuidev/core';
+	import { longpress } from '@svelteuidev/composables';
+
+    let pressed = false;
+	let duration = 2000;
+</script>
+
+<Stack align='center'>
+    <div>
+        <input type=range bind:value={duration} max={2000} step={100} />
+        {duration}ms
+    </div>
+
+    <Button 
+        use={[[longpress, duration]]}
+        on:longpress="{() => pressed = true}"
+        on:mouseenter="{() => pressed = false}"
+    >
+        Press and hold
+    </Button>
+
+    {#if pressed}
+        <p>Congratulations, you pressed and held for {duration} ms</p>
+    {/if}
+</Stack>

--- a/packages/svelteui-demos/src/lib/demos/composables/actions/use-page-leave/index.ts
+++ b/packages/svelteui-demos/src/lib/demos/composables/actions/use-page-leave/index.ts
@@ -1,0 +1,1 @@
+export * as usage from './usage.svelte';

--- a/packages/svelteui-demos/src/lib/demos/composables/actions/use-page-leave/usage.svelte
+++ b/packages/svelteui-demos/src/lib/demos/composables/actions/use-page-leave/usage.svelte
@@ -1,0 +1,31 @@
+<script lang="ts" context="module">
+	import type { CodeDemoType, CodeDemoConfiguration } from '$lib/types';
+
+	const code = `
+<script>
+    import { pageleave } from '@svelteuidev/composables';
+
+    $: count = 0;
+<\/script>
+
+<div use:pageleave={() => count++}>Move the mouse off the page to see the counter go up: {count}</div>`;
+
+	export const type: CodeDemoType['type'] = 'demo';
+
+	export const configuration: CodeDemoConfiguration = {
+		code
+	};
+</script>
+
+<script>
+	import { Center } from '@svelteuidev/core';
+	import { pageleave } from '@svelteuidev/composables';
+
+    $: count = 0;
+</script>
+
+<Center>
+    <div use:pageleave={() => count++}>
+        Move the mouse off the page to see the counter go up: {count}
+    </div>
+</Center>

--- a/packages/svelteui-demos/src/lib/demos/composables/actions/use-persistent-tab/index.ts
+++ b/packages/svelteui-demos/src/lib/demos/composables/actions/use-persistent-tab/index.ts
@@ -1,0 +1,1 @@
+export * as usage from './usage.svelte';

--- a/packages/svelteui-demos/src/lib/demos/composables/actions/use-persistent-tab/usage.svelte
+++ b/packages/svelteui-demos/src/lib/demos/composables/actions/use-persistent-tab/usage.svelte
@@ -1,0 +1,41 @@
+<script lang="ts" context="module">
+	import type { CodeDemoType, CodeDemoConfiguration } from '$lib/types';
+
+	const code = `
+<script>
+    import { persistenttab } from '@svelteuidev/composables';
+
+    let isNotClosable = false;
+<\/script>
+
+<button on:click={() => isNotClosable = !isNotClosable}>
+    {isNotClosable ? "Can't close tab" : 'Can close tab'}
+</button>
+
+<div use:persistenttab={isNotClosable}>
+    Something important that the user wouldn't want to lose to a page refresh or close
+</div>`;
+
+	export const type: CodeDemoType['type'] = 'demo';
+
+	export const configuration: CodeDemoConfiguration = {
+		code
+	};
+</script>
+
+<script>
+	import { Stack } from '@svelteuidev/core';
+	import { persistenttab } from '@svelteuidev/composables';
+
+    let isNotClosable = false;
+</script>
+
+<Stack align='center'>
+    <button on:click={() => isNotClosable = !isNotClosable}>
+        {isNotClosable ? "Can't close tab" : 'Can close tab'}
+    </button>
+    
+    <div use:persistenttab={isNotClosable}>
+        Something important that the user wouldn't want to lose to a page refresh or close
+    </div>
+</Stack>

--- a/packages/svelteui-demos/src/lib/demos/composables/actions/use-portal/index.ts
+++ b/packages/svelteui-demos/src/lib/demos/composables/actions/use-portal/index.ts
@@ -1,0 +1,1 @@
+export * as usage from './usage.svelte';

--- a/packages/svelteui-demos/src/lib/demos/composables/actions/use-portal/usage.svelte
+++ b/packages/svelteui-demos/src/lib/demos/composables/actions/use-portal/usage.svelte
@@ -1,0 +1,56 @@
+<script lang="ts" context="module">
+	import type { CodeDemoType, CodeDemoConfiguration } from '$lib/types';
+
+	const code = `
+<script>
+    import { Box, Button } from '@svelteuidev/core';
+    import { portal } from '@svelteuidev/composables';
+
+    let magic = false;
+<\/script>
+
+{#if magic}
+    <div>
+        Look at the top of the page
+    </div>
+{/if}
+<div>
+    <Box 
+        use={[[portal, magic ? 'h1' : null]]}
+        css={{bc: 'white', border: '1px solid black', br: '$md', padding: '$md'}} 
+    >
+        I'm being rendered {magic ? 'outside' : 'inside'} of the preview
+    </Box>
+</div>
+<Button on:click={() => magic = !magic}>Click me to see the magic</Button>`;
+
+	export const type: CodeDemoType['type'] = 'demo';
+
+	export const configuration: CodeDemoConfiguration = {
+		code
+	};
+</script>
+
+<script>
+	import { Box, Button, Stack } from '@svelteuidev/core';
+	import { portal } from '@svelteuidev/composables';
+
+    let magic = false
+</script>
+
+<Stack align='center'>
+    {#if magic}
+        <div>
+            Look at the top of the page
+        </div>
+    {/if}
+    <div>
+        <Box 
+            use={[[portal, magic ? 'h1' : null]]}
+            css={{bc: 'white', border: '1px solid black', br: '$md', padding: '$md'}} 
+        >
+            I'm being rendered {magic ? 'outside' : 'inside'} of the preview
+        </Box>
+    </div>
+    <Button on:click={() => magic = !magic}>Click me to see the magic</Button>
+</Stack>

--- a/packages/svelteui-demos/src/lib/demos/composables/actions/use-tab-leave/index.ts
+++ b/packages/svelteui-demos/src/lib/demos/composables/actions/use-tab-leave/index.ts
@@ -1,0 +1,1 @@
+export * as usage from './usage.svelte';

--- a/packages/svelteui-demos/src/lib/demos/composables/actions/use-tab-leave/usage.svelte
+++ b/packages/svelteui-demos/src/lib/demos/composables/actions/use-tab-leave/usage.svelte
@@ -1,0 +1,31 @@
+<script lang="ts" context="module">
+	import type { CodeDemoType, CodeDemoConfiguration } from '$lib/types';
+
+	const code = `
+<script>
+    import { tableave } from '@svelteuidev/composables';
+
+    $: count = 0;
+<\/script>
+
+<div use:tableave={() => count++}>Switch the tab to see the counter go up: {count}</div>`;
+
+	export const type: CodeDemoType['type'] = 'demo';
+
+	export const configuration: CodeDemoConfiguration = {
+		code
+	};
+</script>
+
+<script>
+	import { Center } from '@svelteuidev/core';
+	import { tableave } from '@svelteuidev/composables';
+
+    $: count = 0;
+</script>
+
+<Center>
+    <div use:tableave={() => count++}>
+        Switch the tab to see the counter go up: {count}
+    </div>
+</Center>


### PR DESCRIPTION
- Update composables old docs to use demos.
- Fixed custom event name of `longpress` action.

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `npm run lint` or just run `npm run repo:prepush` and check to see if it's passing.
