### PR TITLE
[docs] Menu

### DIFF
--- a/docs/src/includes/sidebar.md
+++ b/docs/src/includes/sidebar.md
@@ -95,9 +95,10 @@
   - [Skeleton](core/skeleton)
 - **<Stack/><Space w="md" />Overlay**
   - [Affix](core/affix)
+  - [Menu](core/menu)
+  - [Modal](core/modal)
   - [Overlay](core/overlay)
   - [Tooltip](core/tooltip)
-  - [Modal](core/modal)
 - **<LetterCaseToggle/><Space w="md" />Typography**
   - [Code](core/code)
   - [Text](core/text)

--- a/docs/src/pages/core/menu.md
+++ b/docs/src/pages/core/menu.md
@@ -1,0 +1,145 @@
+---
+title: Menu
+group: 'svelteuidev-core'
+packageGroup: '@svelteuidev/core'
+slug: /core/menu/
+category: 'overlay'
+description: 'Combine a list of secondary actions into single interactive area'
+import: "import { Menu } from '@svelteuidev/core';"
+source: 'svelteui-core/src/lib/components/Menu/Menu.svelte'
+docs: 'core/menu.md'
+---
+
+<script>
+	import { Demo, MenuDemos } from '@svelteuidev/demos';
+  	import { Heading } from 'components';
+</script>
+
+<Heading />
+
+## Usage
+
+<Demo demo={MenuDemos.usage} />
+
+## Controlled
+
+```svelte
+<script lang="ts">
+	import { Menu } from '@svelteuidev/core';
+
+    let opened = false;
+
+    function onOpen() {}
+    function onClose() {}
+</script>
+
+<Menu {opened} on:open={onOpen} onClose={onClose}>
+    <!-- ... -->
+</Menu>
+```
+
+## Show menu on hover
+
+To show meny on hover set the following props:
+- `trigger` to `hover`
+- `delay` to number in ms (defaults to 0)
+
+In this case, menu will use `mouseenter` and `focus` events instead of `click`:
+
+<Demo demo={MenuDemos.hover} />
+
+## Menu.Item component
+
+`Menu.Item` renders a  button and accepts following props:
+
+- `icon` – icon on the left
+- `disabled` – disables item
+- `...others` – Menu.Item produces a button element, all other props will be spread to it
+
+The right section of `Menu.Item` can be customized with the slot `rightSection`.
+
+```svelte
+<script lang="ts">
+	import { Menu, Text } from '@svelteuidev/core';
+    import { Gear } from 'radix-icons-svelte';
+</script>
+
+<Menu>
+    <Menu.Item icon={Gear} on:click={() => console.log('Hi!')}>
+        <svelte:fragment slot='rightSection'>
+            <Text size="xs" color="dimmed">⌘K</Text>
+        </svelte:fragment>
+        Settings
+    </Menu.Item>
+</Menu>
+```
+
+## Disabled item
+
+<Demo demo={MenuDemos.disabled} />
+
+<!-- ## Custom control
+
+To be implemented
+
+## Custom control with component
+
+To be implemented -->
+
+## Change menu position
+
+Menu is rendered inside [Portal](core/portal) and its position is controlled with the following props:
+
+- `position` – left, right, bottom, top
+- `placement` – start, center, end
+- `gutter` – spacing between menu body and target element in px
+- `withArrow` – displays arrow, arrow position is calculated by `position` and `placement` props
+
+<Demo demo={MenuDemos.position} />
+
+## Change transition
+
+Menu supports the same transition as [Popper](core/popper). You can customize transition, its parameters or even provide a custom transition.
+
+<Demo demo={MenuDemos.transition} />
+
+## Size and shadow
+
+You can use predefined shadows defined in [theme shadows](theming/default-theme#shadows) or your own:
+
+<Demo demo={MenuDemos.size} />
+
+## Custom component as Menu.Item
+
+By default, menu items render as button, to change that set `root` prop on `Menu.Item` component:
+
+```svelte
+// Regular anchor as Menu.Item root element
+<Menu.Item root="a" href="https://svelteui.org" target="_blank" />
+
+// Svelte component as Menu.Item root element
+<Menu.Item root={CustomComponent} />
+```
+
+<Demo demo={MenuDemos.custom} />
+
+## Add your styles
+
+You can change styles of any element in the button component with the `override` prop or by setting a class name. For example, you can change the hovered item color:
+
+<Demo demo={MenuDemos.styles} />
+
+## Accessibility and usability
+
+To make Menu more accessible for users with screen readers it is require to set the prop `menuButtonLabel`, specially when using a control that does not include text, for example, the default one.
+
+Menu behavior and properties:
+
+- When menu is opened, focus is trapped inside
+- When menu is closed, focus is moved back to menu control
+- Focus inside menu is controlled with up and down arrows, tab key has no effect
+- By default, when menu item is clicked, menu closes, change it with closeOnItemClick prop
+- Menu is closed when user clicks outside or presses escape
+- Menu control has `aria-haspopup`, `aria-expanded`, `aria-controls` and `aria-label` attributes. `aria-label` is defined by the `menuButtonLabel` prop
+- Menu body has `menu` role, aria`-orientation` is always set to vertical
+- Menu item has `menuitem` role

--- a/docs/src/pages/core/modal.md
+++ b/docs/src/pages/core/modal.md
@@ -3,7 +3,7 @@ title: Modal
 group: 'svelteuidev-core'
 packageGroup: '@svelteuidev/core'
 slug: /core/modal/
-category: 'data-display'
+category: 'overlay'
 description: 'Modal with optional header'
 import: "import { Modal } from '@svelteuidev/core';"
 source: 'svelteui-core/src/lib/components/Modal/Modal.svelte'

--- a/packages/svelteui-core/src/lib/components/Menu/Menu.svelte
+++ b/packages/svelteui-core/src/lib/components/Menu/Menu.svelte
@@ -39,8 +39,8 @@
 		gutter: PopperProps['gutter'] = 5,
 		placement: PopperProps['placement'] = 'start',
 		position: PopperProps['position'] = 'bottom',
-		transition: $$MenuProps['transition'] = 'scale',
-		transitionOptions: $$MenuProps['transitionOptions'] = { duration: 300 };
+		transition: $$MenuProps['transition'] = 'fade',
+		transitionOptions: $$MenuProps['transitionOptions'] = { duration: 100 };
 	export { className as class };
 
 	const dispatch = createEventDispatcher();
@@ -162,6 +162,7 @@
 	{...$$restProps}
 >
 	<MenuIcon
+		bind:element={referenceElement}
 		role="button"
 		aria-haspopup="menu"
 		aria-expanded={_opened}
@@ -172,34 +173,32 @@
 		on:keydown={(event) => handleKeyDown(castKeyboardEvent(event))}
 		on:mouseenter={() => (trigger === 'hover' ? handleOpen() : null)}
 	/>
-	{#if _opened}
-		<div transition:_transition={transitionOptions}>
-			<Popper
-				{referenceElement}
-				mounted={_opened}
-				arrowSize={3}
-				arrowClassName={classes.arrow}
-				{position}
-				{placement}
-				{gutter}
-				{withArrow}
-				{zIndex}
-				{withinPortal}
-			>
-				<Paper
-					bind:element={dropdownElement}
-					use={[[clickoutside, clickOutsideParams]]}
-					id={uuid}
-					role="menu"
-					class={cx(classes['svelteui-Menu-body'])}
-					aria-orientation="vertical"
-					{radius}
-					on:mouseleave={() => (hovered = -1)}
-					{shadow}
-				>
-					<slot />
-				</Paper>
-			</Popper>
-		</div>
-	{/if}
+	<Popper
+		reference={referenceElement}
+		mounted={_opened}
+		arrowSize={3}
+		arrowClassName={classes.arrow}
+		{transition}
+		{transitionOptions}
+		{position}
+		{placement}
+		{gutter}
+		{withArrow}
+		{zIndex}
+		{withinPortal}
+	>
+		<Paper
+			bind:element={dropdownElement}
+			use={[[clickoutside, clickOutsideParams]]}
+			id={uuid}
+			role="menu"
+			class={cx(classes['svelteui-Menu-body'])}
+			aria-orientation="vertical"
+			{radius}
+			on:mouseleave={() => (hovered = -1)}
+			{shadow}
+		>
+			<slot />
+		</Paper>
+	</Popper>
 </Box>

--- a/packages/svelteui-core/src/lib/components/Menu/Menu.svelte
+++ b/packages/svelteui-core/src/lib/components/Menu/Menu.svelte
@@ -4,7 +4,7 @@
 
 <script lang="ts">
 	import useStyles, { getNextItem, getPreviousItem } from './Menu.styles';
-	import { setContext } from 'svelte';
+	import { createEventDispatcher, setContext } from 'svelte';
 	import { writable } from 'svelte/store';
 	import { Box } from '../Box';
 	import { Popper } from '../Popper';
@@ -43,11 +43,12 @@
 		transitionOptions: $$MenuProps['transitionOptions'] = { duration: 300 };
 	export { className as class };
 
+	const dispatch = createEventDispatcher();
+
 	let delayTimeout: number;
 	let referenceElement: HTMLButtonElement;
 	let dropdownElement: HTMLDivElement;
 	let hovered: number = -1;
-	let _transition = getTransition(transition) as any;
 
 	const clickOutsideParams: { enabled: boolean; callback: (any) => unknown } = {
 		enabled: true,
@@ -64,12 +65,14 @@
 		if (_opened) {
 			_opened = false;
 			opened = false;
+			dispatch('close');
 		}
 	};
 
 	const handleOpen = () => {
 		_opened = true;
 		opened = true;
+		dispatch('open');
 	};
 
 	const toggleMenu = () => {

--- a/packages/svelteui-core/src/lib/components/Menu/MenuIcon.svelte
+++ b/packages/svelteui-core/src/lib/components/Menu/MenuIcon.svelte
@@ -11,6 +11,7 @@
 		title?: string;
 	}
 
+	export let element: $$Props['element'] = undefined;
 	export let size: $$Props['size'] = 15;
 	export let className: string = '';
 	export { className as class };
@@ -19,6 +20,7 @@
 </script>
 
 <ActionIcon
+	bind:element
 	use={[forwardEvents, [useActions, $$restProps?.use]]}
 	class={className}
 	{...$$restProps}

--- a/packages/svelteui-core/src/lib/components/Menu/MenuItem/MenuItem.styles.ts
+++ b/packages/svelteui-core/src/lib/components/Menu/MenuItem/MenuItem.styles.ts
@@ -6,9 +6,7 @@ export interface SharedMenuItemProps extends DefaultProps {
 	color?: SvelteUIColor;
 	disabled?: boolean;
 	icon?: Component | HTMLOrSVGElement;
-	rightSection?: Component | HTMLOrSVGElement;
 	iconProps?: Record<string, any>;
-	rightSectionProps?: Record<string, any>;
 }
 
 export interface MenuItemProps extends SharedMenuItemProps {

--- a/packages/svelteui-core/src/lib/components/Menu/MenuItem/MenuItem.svelte
+++ b/packages/svelteui-core/src/lib/components/Menu/MenuItem/MenuItem.svelte
@@ -17,9 +17,7 @@
 		color: $$MenuItemProps['color'] = undefined,
 		disabled: $$MenuItemProps['disabled'] = false,
 		icon: $$MenuItemProps['icon'] = undefined,
-		rightSection: $$MenuItemProps['rightSection'] = undefined,
-		iconProps: $$MenuItemProps['iconProps'] = undefined,
-		rightSectionProps: $$MenuItemProps['rightSectionProps'] = undefined;
+		iconProps: $$MenuItemProps['iconProps'] = undefined;
 	export { className as class };
 
 	const state: Writable<MenuContextValue> = getContext(ctx);
@@ -58,9 +56,7 @@
 			<div class={classes.itemLabel}>
 				<slot />
 			</div>
-			{#if rightSection}
-				<svelte:component this={rightSection} {...rightSectionProps} />
-			{/if}
+			<slot name='rightSection' />
 		</div>
 	</div>
 </Box>

--- a/packages/svelteui-core/src/lib/components/Popper/Popper.styles.ts
+++ b/packages/svelteui-core/src/lib/components/Popper/Popper.styles.ts
@@ -1,6 +1,7 @@
 import { createStyles } from '$lib/styles';
 import type { TransitionConfig, EasingFunction } from 'svelte/transition';
 import type { DefaultProps } from '$lib/styles';
+import type { TransitionName, TransitionOptions } from '$lib/internal';
 
 export interface PopperProps extends DefaultProps<HTMLElement> {
 	position?: 'top' | 'left' | 'bottom' | 'right';
@@ -12,9 +13,9 @@ export interface PopperProps extends DefaultProps<HTMLElement> {
 	withArrow?: boolean;
 	zIndex?: number;
 	transition?: Transition;
-	transitionDuration?: number;
+	transitionOptions?: TransitionOptions;
 	exitTransition?: Transition;
-	exitTransitionDuration?: number;
+	exitTransitionOptions?: TransitionOptions;
 	mounted?: boolean;
 	reference?: HTMLElement;
 	withinPortal?: boolean;
@@ -23,7 +24,9 @@ interface PopperStyleParams {
 	arrowSize: number;
 	zIndex: number;
 }
-export type Transition = (node: Element, params: TransitionParams) => TransitionConfig;
+export type Transition =
+	| TransitionName
+	| ((node: Element, params: TransitionParams) => TransitionConfig);
 
 interface TransitionParams {
 	delay?: number;

--- a/packages/svelteui-core/src/lib/components/Popper/Popper.svelte
+++ b/packages/svelteui-core/src/lib/components/Popper/Popper.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
 	import useStyles from './Popper.styles';
 	import { calculateArrowPlacement } from './Popper.styles';
-	import { fade } from 'svelte/transition';
 	import { arrow, autoUpdate, computePosition, offset, flip, shift } from '@floating-ui/dom';
 	import { get_current_component, onDestroy } from 'svelte/internal';
-	import { createEventForwarder, useActions } from '$lib/internal';
+	import { createEventForwarder, getTransition, useActions } from '$lib/internal';
 	import type { Placement } from '@floating-ui/dom';
 	import type { PopperProps as $$PopperProps } from './Popper.styles';
 
@@ -20,10 +19,10 @@
 		arrowClassName: $$PopperProps['arrowClassName'] = 'arrow',
 		withArrow: $$PopperProps['withArrow'] = false,
 		zIndex: $$PopperProps['zIndex'] = 1,
-		transition: $$PopperProps['transition'] = fade,
-		transitionDuration: $$PopperProps['transitionDuration'] = 100,
+		transition: $$PopperProps['transition'] = 'fade',
+		transitionOptions: $$PopperProps['transitionOptions'] = { duration: 100 },
 		exitTransition: $$PopperProps['exitTransition'] = transition,
-		exitTransitionDuration: $$PopperProps['exitTransitionDuration'] = transitionDuration,
+		exitTransitionOptions: $$PopperProps['exitTransitionOptions'] = transitionOptions,
 		mounted: $$PopperProps['mounted'] = false,
 		reference: $$PopperProps['reference'] = null;
 	export { className as class };
@@ -95,6 +94,8 @@
 	}
 
 	$: _mounted = mounted;
+	$: _transition = getTransition(transition) as any;
+	$: _exitTransition = getTransition(exitTransition) as any;
 	$: updatePopper({ ...$$props });
 	$: ({ cx, classes, getStyles } = useStyles({ arrowSize, zIndex }));
 </script>
@@ -133,8 +134,8 @@ and placement options.
 		use:useActions={use}
 		use:forwardEvents
 		class={cx(className, getStyles({ css: override }))}
-		in:transition={{ duration: transitionDuration }}
-		out:exitTransition={{ duration: exitTransitionDuration }}
+		in:_transition={transitionOptions}
+		out:_exitTransition={exitTransitionOptions}
 	>
 		{#if withArrow}
 			<div

--- a/packages/svelteui-core/src/lib/internal/utils/get-transition/get-transition.ts
+++ b/packages/svelteui-core/src/lib/internal/utils/get-transition/get-transition.ts
@@ -1,4 +1,5 @@
 import { fade, blur, fly, slide, scale, draw } from 'svelte/transition';
+import type { TransitionConfig, EasingFunction } from 'svelte/transition';
 import type {
 	FadeParams,
 	BlurParams,
@@ -22,10 +23,23 @@ export type TransitionOptions =
 	| FlyParams
 	| SlideParams
 	| ScaleParams
-	| DrawParams;
+	| DrawParams
+	| TransitionParams;
 
-export function getTransition(name: TransitionName): Transition {
+interface TransitionParams {
+	delay?: number;
+	duration?: number;
+	easing?: EasingFunction;
+	css?: (t: number, u: number) => string;
+	tick?: (t: number, u: number) => void;
+}
+
+export function getTransition(
+	name: TransitionName | ((node: Element, params: TransitionParams) => TransitionConfig)
+): Transition {
 	let transition: Transition;
+
+	if (typeof name === 'function') return name;
 
 	switch (name) {
 		case 'fade':
@@ -48,7 +62,6 @@ export function getTransition(name: TransitionName): Transition {
 			break;
 		default:
 			throw new Error('You must enter a valid transition name');
-			break;
 	}
 	return transition;
 }

--- a/packages/svelteui-core/src/lib/styles/theme/functions/fns/variant/variant.ts
+++ b/packages/svelteui-core/src/lib/styles/theme/functions/fns/variant/variant.ts
@@ -1,4 +1,4 @@
-import { useSvelteUIThemeContext } from '../../../';
+import { useSvelteUITheme, useSvelteUIThemeContext } from '../../../';
 import { rgba } from '../rgba/rgba';
 import { themeColor } from '../theme-color/theme-color';
 import type { SvelteUIColor, SvelteUIGradient } from '../../../types';
@@ -33,7 +33,7 @@ const DEFAULT_GRADIENT = {
  * @returns an object with border, background, color, and hover property styles based on the variant
  */
 export function variant({ variant, color, gradient }: VariantInput): VariantOutput {
-	const theme = useSvelteUIThemeContext().theme;
+	const theme = useSvelteUIThemeContext()?.theme || useSvelteUITheme();
 	const primaryShade = 6;
 
 	if (variant === 'light') {

--- a/packages/svelteui-dates/package.json
+++ b/packages/svelteui-dates/package.json
@@ -43,8 +43,6 @@
 		"package": "svelte-kit package",
 		"pub": "npm publish package/",
 		"sort": "npx sort-package-json",
-		"test": "vitest --run",
-		"test:watch": "vitest",
 		"update:lockfile": "npm i",
 		"watch": "svelte-kit package -w"
 	},

--- a/packages/svelteui-demos/src/lib/demos/core/Menu/Menu.demo.custom.svelte
+++ b/packages/svelteui-demos/src/lib/demos/core/Menu/Menu.demo.custom.svelte
@@ -1,0 +1,46 @@
+<script lang="ts" context="module">
+	import type { CodeDemoType, CodeDemoConfiguration } from '$lib/types';
+	const code = `
+<script>
+	import { Menu } from '@svelteuidev/core';
+	import { ExternalLink } from 'radix-icons-svelte';
+<\/script>
+
+<Menu>
+    <Menu.Item root='a' href='https://svelteui.org'>SvelteUI Website</Menu.Item>
+    <Menu.Item
+        icon={ExternalLink}
+        root='a'
+        href='https://svelteui.org'
+        target='_blank'
+    >
+        External Link
+    </Menu.Item>
+</Menu>
+`;
+
+	export const type: CodeDemoType['type'] = 'demo';
+
+	export const configuration: CodeDemoConfiguration = {
+		code
+	};
+</script>
+
+<script lang="ts">
+	import { Center, Menu } from '@svelteuidev/core';
+	import { ExternalLink } from 'radix-icons-svelte';
+</script>
+
+<Center>
+    <Menu>
+        <Menu.Item root='a' href='https://svelteui.org'>SvelteUI Website</Menu.Item>
+        <Menu.Item
+            icon={ExternalLink}
+            root='a'
+            href='https://svelteui.org'
+            target='_blank'
+        >
+            External Link
+        </Menu.Item>
+    </Menu>
+</Center>

--- a/packages/svelteui-demos/src/lib/demos/core/Menu/Menu.demo.disabled.svelte
+++ b/packages/svelteui-demos/src/lib/demos/core/Menu/Menu.demo.disabled.svelte
@@ -1,0 +1,60 @@
+<script lang="ts" context="module">
+	import type { CodeDemoType, CodeDemoConfiguration } from '$lib/types';
+	const code = `
+<script>
+	import { Divider, Menu, Text } from '@svelteuidev/core';
+	import { Camera, ChatBubble, Gear, MagnifyingGlass, Trash, Width } from 'radix-icons-svelte';
+<\/script>
+
+<Menu>
+    <Menu.Label>Application</Menu.Label>
+    <Menu.Item icon={Gear}>Settings</Menu.Item>
+    <Menu.Item icon={ChatBubble}>Messages</Menu.Item>
+    <Menu.Item icon={Camera}>Gallery</Menu.Item>
+    <Menu.Item icon={MagnifyingGlass} disabled>
+        <svelte:fragment slot='rightSection'>
+            <Text size="xs" color="dimmed">⌘K</Text>
+        </svelte:fragment>
+        Search
+    </Menu.Item>
+
+    <Divider />
+
+    <Menu.Label>Danger zone</Menu.Label>
+    <Menu.Item icon={Width}>Transfer my data</Menu.Item>
+    <Menu.Item color="red" icon={Trash}>Delete my account</Menu.Item>
+</Menu>
+`;
+
+	export const type: CodeDemoType['type'] = 'demo';
+
+	export const configuration: CodeDemoConfiguration = {
+		code
+	};
+</script>
+
+<script lang="ts">
+	import { Center, Divider, Menu, Text } from '@svelteuidev/core';
+	import { Camera, ChatBubble, Gear, MagnifyingGlass, Trash, Width } from 'radix-icons-svelte';
+</script>
+
+<Center>
+    <Menu>
+        <Menu.Label>Application</Menu.Label>
+        <Menu.Item icon={Gear}>Settings</Menu.Item>
+        <Menu.Item icon={ChatBubble}>Messages</Menu.Item>
+        <Menu.Item icon={Camera}>Gallery</Menu.Item>
+        <Menu.Item icon={MagnifyingGlass} disabled>
+            <svelte:fragment slot='rightSection'>
+                <Text size="xs" color="dimmed">⌘K</Text>
+            </svelte:fragment>
+            Search
+        </Menu.Item>
+    
+        <Divider />
+    
+        <Menu.Label>Danger zone</Menu.Label>
+        <Menu.Item icon={Width}>Transfer my data</Menu.Item>
+        <Menu.Item color="red" icon={Trash}>Delete my account</Menu.Item>
+    </Menu>
+</Center>

--- a/packages/svelteui-demos/src/lib/demos/core/Menu/Menu.demo.hover.svelte
+++ b/packages/svelteui-demos/src/lib/demos/core/Menu/Menu.demo.hover.svelte
@@ -1,0 +1,60 @@
+<script lang="ts" context="module">
+	import type { CodeDemoType, CodeDemoConfiguration } from '$lib/types';
+	const code = `
+<script>
+	import { Divider, Menu, Text } from '@svelteuidev/core';
+	import { Camera, ChatBubble, Gear, MagnifyingGlass, Trash, Width } from 'radix-icons-svelte';
+<\/script>
+
+<Menu trigger='hover' delay={500}>
+    <Menu.Label>Application</Menu.Label>
+    <Menu.Item icon={Gear}>Settings</Menu.Item>
+    <Menu.Item icon={ChatBubble}>Messages</Menu.Item>
+    <Menu.Item icon={Camera}>Gallery</Menu.Item>
+    <Menu.Item icon={MagnifyingGlass}>
+        <svelte:fragment slot='rightSection'>
+            <Text size="xs" color="dimmed">⌘K</Text>
+        </svelte:fragment>
+        Search
+    </Menu.Item>
+
+    <Divider />
+
+    <Menu.Label>Danger zone</Menu.Label>
+    <Menu.Item icon={Width}>Transfer my data</Menu.Item>
+    <Menu.Item color="red" icon={Trash}>Delete my account</Menu.Item>
+</Menu>
+`;
+
+	export const type: CodeDemoType['type'] = 'demo';
+
+	export const configuration: CodeDemoConfiguration = {
+		code
+	};
+</script>
+
+<script lang="ts">
+	import { Center, Divider, Menu, Text } from '@svelteuidev/core';
+	import { Camera, ChatBubble, Gear, MagnifyingGlass, Trash, Width } from 'radix-icons-svelte';
+</script>
+
+<Center>
+    <Menu trigger='hover' delay={500}>
+        <Menu.Label>Application</Menu.Label>
+        <Menu.Item icon={Gear}>Settings</Menu.Item>
+        <Menu.Item icon={ChatBubble}>Messages</Menu.Item>
+        <Menu.Item icon={Camera}>Gallery</Menu.Item>
+        <Menu.Item icon={MagnifyingGlass}>
+            <svelte:fragment slot='rightSection'>
+                <Text size="xs" color="dimmed">⌘K</Text>
+            </svelte:fragment>
+            Search
+        </Menu.Item>
+    
+        <Divider />
+    
+        <Menu.Label>Danger zone</Menu.Label>
+        <Menu.Item icon={Width}>Transfer my data</Menu.Item>
+        <Menu.Item color="red" icon={Trash}>Delete my account</Menu.Item>
+    </Menu>
+</Center>

--- a/packages/svelteui-demos/src/lib/demos/core/Menu/Menu.demo.position.svelte
+++ b/packages/svelteui-demos/src/lib/demos/core/Menu/Menu.demo.position.svelte
@@ -1,0 +1,91 @@
+<script lang="ts" context="module">
+	import type { ConfiguratorDemoType, ConfiguratorDemoConfiguration } from '$lib/types';
+
+	const codeTemplate = (props: string) => `
+<script>
+    import { Divider, Menu, Text } from '@svelteuidev/core';
+<\/script>
+
+<Menu opened={true}${props}>
+    <Menu.Label>Application</Menu.Label>
+    <Menu.Item icon={Gear}>Settings</Menu.Item>
+    <Menu.Item icon={ChatBubble}>Messages</Menu.Item>
+    <Menu.Item icon={Camera}>Gallery</Menu.Item>
+    <Menu.Item icon={MagnifyingGlass} disabled>
+        <svelte:fragment slot='rightSection'>
+            <Text size="xs" color="dimmed">⌘K</Text>
+        </svelte:fragment>
+        Search
+    </Menu.Item>
+
+    <Divider />
+
+    <Menu.Label>Danger zone</Menu.Label>
+    <Menu.Item icon={Width}>Transfer my data</Menu.Item>
+    <Menu.Item color="red" icon={Trash}>Delete my account</Menu.Item>
+</Menu>
+`;
+
+	export const type: ConfiguratorDemoType['type'] = 'configurator';
+
+	export const configuration: ConfiguratorDemoConfiguration = {
+		codeTemplate,
+		configurator: [
+			{
+				name: 'position',
+				type: 'select',
+				data: [
+					{ label: 'bottom', value: 'bottom' },
+					{ label: 'top', value: 'top' },
+					{ label: 'right', value: 'right' },
+					{ label: 'left', value: 'left' }
+				],
+				initialValue: 'bottom',
+				defaultValue: 'bottom'
+			},
+			{
+				name: 'placement',
+				type: 'select',
+				data: [
+					{ label: 'start', value: 'start' },
+					{ label: 'center', value: 'center' },
+					{ label: 'end', value: 'end' }
+				],
+				initialValue: 'start',
+				defaultValue: 'start'
+			},
+			{ name: 'gutter', type: 'number', initialValue: 5, min: -20, max: 20 },
+			{ name: 'withArrow', label: 'With arrow', type: 'boolean', initialValue: false, defaultValue: false }
+		],
+		multiline: true
+	};
+</script>
+
+<script lang="ts">
+	import type { MenuProps } from '@svelteuidev/core';
+	import { Center, Divider, Menu, Text } from '@svelteuidev/core';
+    import { Camera, ChatBubble, Gear, MagnifyingGlass, Trash, Width } from 'radix-icons-svelte';
+
+	export let props: Partial<MenuProps> = {};
+</script>
+
+<Center>
+    <Menu opened={true} {...props}>
+        <Menu.Label>Application</Menu.Label>
+        <Menu.Item icon={Gear}>Settings</Menu.Item>
+        <Menu.Item icon={ChatBubble}>Messages</Menu.Item>
+        <Menu.Item icon={Camera}>Gallery</Menu.Item>
+        <Menu.Item icon={MagnifyingGlass} disabled>
+            <svelte:fragment slot='rightSection'>
+                <Text size="xs" color="dimmed">⌘K</Text>
+            </svelte:fragment>
+            Search
+        </Menu.Item>
+    
+        <Divider />
+    
+        <Menu.Label>Danger zone</Menu.Label>
+        <Menu.Item icon={Width}>Transfer my data</Menu.Item>
+        <Menu.Item color="red" icon={Trash}>Delete my account</Menu.Item>
+    </Menu>
+</Center>

--- a/packages/svelteui-demos/src/lib/demos/core/Menu/Menu.demo.size.svelte
+++ b/packages/svelteui-demos/src/lib/demos/core/Menu/Menu.demo.size.svelte
@@ -1,0 +1,68 @@
+<script lang="ts" context="module">
+	import type { ConfiguratorDemoType, ConfiguratorDemoConfiguration } from '$lib/types';
+
+	const codeTemplate = (props: string) => `
+<script>
+    import { Divider, Menu, Text } from '@svelteuidev/core';
+<\/script>
+
+<Menu${props}>
+    <Menu.Label>Application</Menu.Label>
+    <Menu.Item icon={Gear}>Settings</Menu.Item>
+    <Menu.Item icon={ChatBubble}>Messages</Menu.Item>
+    <Menu.Item icon={Camera}>Gallery</Menu.Item>
+    <Menu.Item icon={MagnifyingGlass} disabled>
+        <svelte:fragment slot='rightSection'>
+            <Text size="xs" color="dimmed">⌘K</Text>
+        </svelte:fragment>
+        Search
+    </Menu.Item>
+
+    <Divider />
+
+    <Menu.Label>Danger zone</Menu.Label>
+    <Menu.Item icon={Width}>Transfer my data</Menu.Item>
+    <Menu.Item color="red" icon={Trash}>Delete my account</Menu.Item>
+</Menu>
+`;
+
+	export const type: ConfiguratorDemoType['type'] = 'configurator';
+
+	export const configuration: ConfiguratorDemoConfiguration = {
+		codeTemplate,
+		configurator: [
+            { name: 'size', type: 'size', initialValue: 'md', defaultValue: 'md' },
+			{ name: 'shadow', type: 'size', initialValue: 'md', defaultValue: 'md' }
+		],
+		multiline: true
+	};
+</script>
+
+<script lang="ts">
+	import type { MenuProps } from '@svelteuidev/core';
+	import { Center, Divider, Menu, Text } from '@svelteuidev/core';
+    import { Camera, ChatBubble, Gear, MagnifyingGlass, Trash, Width } from 'radix-icons-svelte';
+
+	export let props: Partial<MenuProps> = {};
+</script>
+
+<Center>
+    <Menu {...props}>
+        <Menu.Label>Application</Menu.Label>
+        <Menu.Item icon={Gear}>Settings</Menu.Item>
+        <Menu.Item icon={ChatBubble}>Messages</Menu.Item>
+        <Menu.Item icon={Camera}>Gallery</Menu.Item>
+        <Menu.Item icon={MagnifyingGlass} disabled>
+            <svelte:fragment slot='rightSection'>
+                <Text size="xs" color="dimmed">⌘K</Text>
+            </svelte:fragment>
+            Search
+        </Menu.Item>
+    
+        <Divider />
+    
+        <Menu.Label>Danger zone</Menu.Label>
+        <Menu.Item icon={Width}>Transfer my data</Menu.Item>
+        <Menu.Item color="red" icon={Trash}>Delete my account</Menu.Item>
+    </Menu>
+</Center>

--- a/packages/svelteui-demos/src/lib/demos/core/Menu/Menu.demo.styles.svelte
+++ b/packages/svelteui-demos/src/lib/demos/core/Menu/Menu.demo.styles.svelte
@@ -1,0 +1,80 @@
+<script lang="ts" context="module">
+	import type { CodeDemoType, CodeDemoConfiguration } from '$lib/types';
+	const code = `
+<script>
+	import { Divider, Menu, Text, createStyles } from '@svelteuidev/core';
+	import { Camera, ChatBubble, Gear, MagnifyingGlass, Trash, Width } from 'radix-icons-svelte';
+
+    const useStyles = createStyles(theme => ({
+        root: {
+            '&.itemHovered': {
+                backgroundColor: theme.fn.themeColor(theme.colors.primary, 7),
+                color: theme.colors.white.value,
+            }
+        }
+	}));
+    const { classes } = useStyles();
+<\/script>
+
+<Menu>
+    <Menu.Label>Application</Menu.Label>
+    <Menu.Item icon={Gear} class={classes.root}>Settings</Menu.Item>
+    <Menu.Item icon={ChatBubble} class={classes.root}>Messages</Menu.Item>
+    <Menu.Item icon={Camera} class={classes.root}>Gallery</Menu.Item>
+    <Menu.Item icon={MagnifyingGlass} class={classes.root}>
+        <svelte:fragment slot='rightSection'>
+            <Text size="xs" color="dimmed">⌘K</Text>
+        </svelte:fragment>
+        Search
+    </Menu.Item>
+
+    <Divider />
+
+    <Menu.Label>Danger zone</Menu.Label>
+    <Menu.Item icon={Width} class={classes.root}>Transfer my data</Menu.Item>
+    <Menu.Item color="red" icon={Trash} class={classes.root}>Delete my account</Menu.Item>
+</Menu>
+`;
+
+	export const type: CodeDemoType['type'] = 'demo';
+
+	export const configuration: CodeDemoConfiguration = {
+		code
+	};
+</script>
+
+<script lang="ts">
+	import { Center, Divider, Menu, Text, createStyles } from '@svelteuidev/core';
+	import { Camera, ChatBubble, Gear, MagnifyingGlass, Trash, Width } from 'radix-icons-svelte';
+
+    const useStyles = createStyles(theme => ({
+        root: {
+            '&.itemHovered': {
+                backgroundColor: theme.fn.themeColor(theme.colors.primary, 7),
+                color: theme.colors.white.value,
+            }
+        }
+	}));
+    const { classes } = useStyles();
+</script>
+
+<Center>
+    <Menu>
+        <Menu.Label>Application</Menu.Label>
+        <Menu.Item icon={Gear} class={classes.root}>Settings</Menu.Item>
+        <Menu.Item icon={ChatBubble} class={classes.root}>Messages</Menu.Item>
+        <Menu.Item icon={Camera} class={classes.root}>Gallery</Menu.Item>
+        <Menu.Item icon={MagnifyingGlass} class={classes.root}>
+            <svelte:fragment slot='rightSection'>
+                <Text size="xs" color="dimmed">⌘K</Text>
+            </svelte:fragment>
+            Search
+        </Menu.Item>
+    
+        <Divider />
+    
+        <Menu.Label>Danger zone</Menu.Label>
+        <Menu.Item icon={Width} class={classes.root}>Transfer my data</Menu.Item>
+        <Menu.Item color="red" icon={Trash} class={classes.root}>Delete my account</Menu.Item>
+    </Menu>
+</Center>

--- a/packages/svelteui-demos/src/lib/demos/core/Menu/Menu.demo.transition.svelte
+++ b/packages/svelteui-demos/src/lib/demos/core/Menu/Menu.demo.transition.svelte
@@ -1,0 +1,60 @@
+<script lang="ts" context="module">
+	import type { CodeDemoType, CodeDemoConfiguration } from '$lib/types';
+	const code = `
+<script>
+	import { Divider, Menu, Text } from '@svelteuidev/core';
+	import { Camera, ChatBubble, Gear, MagnifyingGlass, Trash, Width } from 'radix-icons-svelte';
+<\/script>
+
+<Menu transition='fly' transitionOptions={{ y: 200 }}>
+    <Menu.Label>Application</Menu.Label>
+    <Menu.Item icon={Gear}>Settings</Menu.Item>
+    <Menu.Item icon={ChatBubble}>Messages</Menu.Item>
+    <Menu.Item icon={Camera}>Gallery</Menu.Item>
+    <Menu.Item icon={MagnifyingGlass} disabled>
+        <svelte:fragment slot='rightSection'>
+            <Text size="xs" color="dimmed">⌘K</Text>
+        </svelte:fragment>
+        Search
+    </Menu.Item>
+
+    <Divider />
+
+    <Menu.Label>Danger zone</Menu.Label>
+    <Menu.Item icon={Width}>Transfer my data</Menu.Item>
+    <Menu.Item color="red" icon={Trash}>Delete my account</Menu.Item>
+</Menu>
+`;
+
+	export const type: CodeDemoType['type'] = 'demo';
+
+	export const configuration: CodeDemoConfiguration = {
+		code
+	};
+</script>
+
+<script lang="ts">
+	import { Center, Divider, Menu, Text } from '@svelteuidev/core';
+	import { Camera, ChatBubble, Gear, MagnifyingGlass, Trash, Width } from 'radix-icons-svelte';
+</script>
+
+<Center>
+    <Menu transition='fly' transitionOptions={{ y: 200 }}>
+        <Menu.Label>Application</Menu.Label>
+        <Menu.Item icon={Gear}>Settings</Menu.Item>
+        <Menu.Item icon={ChatBubble}>Messages</Menu.Item>
+        <Menu.Item icon={Camera}>Gallery</Menu.Item>
+        <Menu.Item icon={MagnifyingGlass} disabled>
+            <svelte:fragment slot='rightSection'>
+                <Text size="xs" color="dimmed">⌘K</Text>
+            </svelte:fragment>
+            Search
+        </Menu.Item>
+    
+        <Divider />
+    
+        <Menu.Label>Danger zone</Menu.Label>
+        <Menu.Item icon={Width}>Transfer my data</Menu.Item>
+        <Menu.Item color="red" icon={Trash}>Delete my account</Menu.Item>
+    </Menu>
+</Center>

--- a/packages/svelteui-demos/src/lib/demos/core/Menu/Menu.demo.usage.svelte
+++ b/packages/svelteui-demos/src/lib/demos/core/Menu/Menu.demo.usage.svelte
@@ -1,0 +1,60 @@
+<script lang="ts" context="module">
+	import type { CodeDemoType, CodeDemoConfiguration } from '$lib/types';
+	const code = `
+<script>
+	import { Divider, Menu, Text } from '@svelteuidev/core';
+	import { Camera, ChatBubble, Gear, MagnifyingGlass, Trash, Width } from 'radix-icons-svelte';
+<\/script>
+
+<Menu>
+    <Menu.Label>Application</Menu.Label>
+    <Menu.Item icon={Gear}>Settings</Menu.Item>
+    <Menu.Item icon={ChatBubble}>Messages</Menu.Item>
+    <Menu.Item icon={Camera}>Gallery</Menu.Item>
+    <Menu.Item icon={MagnifyingGlass}>
+        <svelte:fragment slot='rightSection'>
+            <Text size="xs" color="dimmed">⌘K</Text>
+        </svelte:fragment>
+        Search
+    </Menu.Item>
+
+    <Divider />
+
+    <Menu.Label>Danger zone</Menu.Label>
+    <Menu.Item icon={Width}>Transfer my data</Menu.Item>
+    <Menu.Item color="red" icon={Trash}>Delete my account</Menu.Item>
+</Menu>
+`;
+
+	export const type: CodeDemoType['type'] = 'demo';
+
+	export const configuration: CodeDemoConfiguration = {
+		code
+	};
+</script>
+
+<script lang="ts">
+	import { Center, Divider, Menu, Text } from '@svelteuidev/core';
+	import { Camera, ChatBubble, Gear, MagnifyingGlass, Trash, Width } from 'radix-icons-svelte';
+</script>
+
+<Center>
+    <Menu>
+        <Menu.Label>Application</Menu.Label>
+        <Menu.Item icon={Gear}>Settings</Menu.Item>
+        <Menu.Item icon={ChatBubble}>Messages</Menu.Item>
+        <Menu.Item icon={Camera}>Gallery</Menu.Item>
+        <Menu.Item icon={MagnifyingGlass}>
+            <svelte:fragment slot='rightSection'>
+                <Text size="xs" color="dimmed">⌘K</Text>
+            </svelte:fragment>
+            Search
+        </Menu.Item>
+    
+        <Divider />
+    
+        <Menu.Label>Danger zone</Menu.Label>
+        <Menu.Item icon={Width}>Transfer my data</Menu.Item>
+        <Menu.Item color="red" icon={Trash}>Delete my account</Menu.Item>
+    </Menu>
+</Center>

--- a/packages/svelteui-demos/src/lib/demos/core/Menu/index.ts
+++ b/packages/svelteui-demos/src/lib/demos/core/Menu/index.ts
@@ -1,0 +1,8 @@
+export * as usage from './Menu.demo.usage.svelte';
+export * as hover from './Menu.demo.hover.svelte';
+export * as disabled from './Menu.demo.disabled.svelte';
+export * as position from './Menu.demo.position.svelte';
+export * as transition from './Menu.demo.transition.svelte';
+export * as size from './Menu.demo.size.svelte';
+export * as custom from './Menu.demo.custom.svelte';
+export * as styles from './Menu.demo.styles.svelte';

--- a/packages/svelteui-demos/src/lib/index.ts
+++ b/packages/svelteui-demos/src/lib/index.ts
@@ -34,6 +34,7 @@ export * as InputWrapperDemos from './demos/core/InputWrapper';
 export * as KbdDemos from './demos/core/Kbd';
 export * as LoaderDemos from './demos/core/Loader';
 export * as MediaQueryDemos from './demos/core/MediaQuery';
+export * as MenuDemos from './demos/core/Menu';
 export * as ModalDemos from './demos/core/Modal';
 export * as NativeSelectDemos from './demos/core/NativeSelect';
 export * as NotificationDemos from './demos/core/Notification';

--- a/packages/svelteui-preprocessors/.prettierignore
+++ b/packages/svelteui-preprocessors/.prettierignore
@@ -7,3 +7,7 @@ package-lock.json
 
 package
 **/package
+
+# temporary
+src/for-demos/**
+./src/for-demos/**

--- a/packages/svelteui-preprocessors/src/for-demos/preprocessors/SourceCode/SourceCode.svelte.d.ts
+++ b/packages/svelteui-preprocessors/src/for-demos/preprocessors/SourceCode/SourceCode.svelte.d.ts
@@ -7,6 +7,7 @@ declare const __propDef: {
         [evt: string]: CustomEvent<any>;
     };
     slots: {
+        // eslint-disable-next-line @typescript-eslint/ban-types
         default: {};
     };
 };


### PR DESCRIPTION
* Docs and demos for Menu
* Fixed position and placement in Menu and modified Menu to use transition logic already present in Popper (which was improved with some of the logic of Menu)

Note: Menu currently has no unit tests because an error was happening with them, will investigate it later

https://user-images.githubusercontent.com/25725586/178994781-7da4a544-5a6f-4bea-80e3-71fe846763f1.mov


### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `npm run lint` or just run `npm run repo:prepush` and check to see if it's passing.
