### PR TITLE
[@svelteui/prism]: change overflow from scroll to auto

### DIFF
--- a/docs/src/components/homepage/HomePageExample.svelte
+++ b/docs/src/components/homepage/HomePageExample.svelte
@@ -118,7 +118,7 @@
 	});
 
 	/** Prism patch until next version */
-	const override = { pre: { overflow: 'scroll', px: '$lgPX' } };
+	const override = { pre: { px: '$lgPX' } };
 	$: ({ cx, classes, getStyles } = useStyles());
 </script>
 

--- a/packages/svelteui-prism/src/lib/dist/Prism/Prism.svelte
+++ b/packages/svelteui-prism/src/lib/dist/Prism/Prism.svelte
@@ -55,7 +55,7 @@
 
 		pre: {
 			margin: 0,
-			overflow: 'scroll'
+			overflow: 'auto'
 		},
 		'pre[data-line]': {
 			paddingTop: 0,


### PR DESCRIPTION
Changed Prism overflow from `scroll` to `auto`

| Before  | Now |
| ------------- | ------------- |
| <img width="1316" alt="image" src="https://user-images.githubusercontent.com/25725586/178998626-6884a3e7-7d81-416c-9f81-8c4e4dc07eda.png"> | <img width="1038" alt="image" src="https://user-images.githubusercontent.com/25725586/178998673-2478b007-910e-4330-891c-ccf074664a27.png">  |

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `npm run lint` or just run `npm run repo:prepush` and check to see if it's passing.
