### PR TITLE
[@svelteui/core]: support number as size in Button

### DIFF
--- a/docs/src/pages/core/button.md
+++ b/docs/src/pages/core/button.md
@@ -82,6 +82,7 @@ Control button font-size, height and padding with `size` and border-radius with 
 <Button radius="lg" /> // -> theme predefined large radius
 <Button radius={10} /> // -> { borderRadius: '10px' }
 <Button size="sm" /> // -> predefined small size
+<Button size={70} /> // -> { height: '70px', padding: '0px 70px' }
 ```
 
 ## Compact

--- a/packages/svelteui-core/src/components/Button/Button.styles.ts
+++ b/packages/svelteui-core/src/components/Button/Button.styles.ts
@@ -145,8 +145,12 @@ export default createStyles(
 				alignItems: 'center',
 				background: null,
 				borderRadius: typeof radius === 'number' ? radius : `$${radius}`,
-				height: sizes[compact ? `compact-${size}` : size].height,
-				padding: sizes[compact ? `compact-${size}` : size].padding,
+				height:
+					typeof size === 'number' ? `${size}px` : sizes[compact ? `compact-${size}` : size].height,
+				padding:
+					typeof size === 'number'
+						? `0px ${size}px`
+						: sizes[compact ? `compact-${size}` : size].padding,
 				fontFamily: '$standard',
 				fontWeight: '$SemiBold',
 				fontSize: `$${size}`,


### PR DESCRIPTION
Support `size` as number (as the prop type already allows) in Button

Fixes #164

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `npm run lint` or just run `npm run repo:prepush` and check to see if it's passing.
