### PR TITLE
[@svelteui/core]: fix select logic that showed previous selected option on reload

### DIFF
--- a/packages/svelteui-core/src/components/Input/Input.styles.ts
+++ b/packages/svelteui-core/src/components/Input/Input.styles.ts
@@ -24,6 +24,7 @@ export interface InputBaseProps extends DefaultProps {
 export interface InputProps extends InputBaseProps {
 	invalid?: boolean;
 	multiline?: boolean;
+	autocomplete?: string;
 }
 
 export interface InputStylesParams {

--- a/packages/svelteui-core/src/components/Input/Input.svelte
+++ b/packages/svelteui-core/src/components/Input/Input.svelte
@@ -28,6 +28,7 @@
 		value: $$Props['value'] = '',
 		invalid: $$Props['invalid'] = false,
 		multiline: $$Props['multiline'] = false,
+		autocomplete: $$Props['autocomplete'] = 'on',
 		placeholder: $$Props['placeholder'] = '';
 	export { className as class };
 
@@ -103,6 +104,7 @@ Base component to create custom inputs
 			{disabled}
 			{id}
 			{placeholder}
+			{autocomplete}
 			aria-invalid={invalid}
 			class:disabled
 			class:invalid
@@ -122,6 +124,7 @@ Base component to create custom inputs
 			{required}
 			{disabled}
 			{id}
+      {autocomplete}
 			aria-invalid={invalid}
 			class:disabled
 			class:invalid

--- a/packages/svelteui-core/src/components/NativeSelect/NativeSelect.svelte
+++ b/packages/svelteui-core/src/components/NativeSelect/NativeSelect.svelte
@@ -92,6 +92,7 @@ Capture user feedback limited to large set of options
 		bind:value
 		root="select"
 		id={uuid}
+		autocomplete="off"
 		invalid={Boolean(error)}
 		override={{ ...base, ...inputStyle }}
 		aria-required={required}
@@ -110,12 +111,12 @@ Capture user feedback limited to large set of options
 		{...$$restProps}
 	>
 		{#if placeholder}
-			<option value="" disabled hidden>
+			<option value="" disabled hidden selected={!value}>
 				{placeholder}
 			</option>
 		{/if}
 		{#each formattedData as item}
-			<option value={item.value} disabled={item.disabled}>
+			<option value={item.value} disabled={item.disabled} selected={item.value === value}>
 				{item.label}
 			</option>
 		{:else}


### PR DESCRIPTION
Fixes #175.

The problem was related to the select logic + autocomplete.
- The select changes on the option is just to double check that the placeholder becomes selected when no value is provided (and a placeholder is provided).
- The autocomplete must be turned off for native select so that the previous option is not selected when reloading the page.

https://user-images.githubusercontent.com/25725586/182816649-cd90b478-793a-4f93-8fef-06653aaa2865.mov


### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `yarn lint` or just run `yarn repo:prepush` and check to see if it's passing.
