### PR TITLE
[core]: migrate to new svelte-package approach

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 	],
 	"scripts": {
 		"build:docs": "yarn workspace svelteui-docs build",
-    "build:storybook": "build-storybook -c configuration/storybook",
+		"build:storybook": "build-storybook -c configuration/storybook",
 		"bump:major": "deno run --unstable --allow-read --allow-write ./scripts/bump.ts major",
 		"bump:minor": "deno run --unstable --allow-read --allow-write ./scripts/bump.ts minor",
 		"bump:next": "deno run --unstable --allow-read --allow-write ./scripts/bump.ts next",
@@ -49,7 +49,7 @@
 		"script:build-docs": "deno run -A --unstable ./scripts/docs/build.ts",
 		"script:pre-release": "deno run --unstable --allow-read --allow-write ./scripts/pre-release.ts",
 		"sort": "npx sort-package-json && turbo run sort && syncpack set-semver-ranges",
-    "storybook": "start-storybook -p 6006 -c configuration/storybook",
+		"storybook": "start-storybook -p 6006 -c configuration/storybook",
 		"sync:repo": "sh scripts/git/sync-branches.sh",
 		"test": "turbo run test --parallel",
 		"watch": "turbo run watch --parallel"
@@ -62,7 +62,7 @@
 	},
 	"devDependencies": {
 		"@rollup/plugin-replace": "4.0.0",
-    "@storybook/addon-actions": "6.5.10",
+		"@storybook/addon-actions": "6.5.10",
 		"@storybook/addon-essentials": "6.5.10",
 		"@storybook/addon-interactions": "6.5.10",
 		"@storybook/addon-links": "6.5.10",

--- a/packages/svelteui-composables/package.json
+++ b/packages/svelteui-composables/package.json
@@ -44,7 +44,7 @@
 		"format": "prettier --write --plugin-search-dir=. .",
 		"generate-types": "deno run --unstable --allow-read --allow-write ../../scripts/generate-types.ts",
 		"lint": "prettier --check --plugin-search-dir=. . && eslint .",
-		"package": "svelte-kit package",
+		"package": "svelte-package",
 		"prepare": "svelte-kit sync",
 		"preview": "vite preview",
 		"pub": "cd package && npm publish",
@@ -54,12 +54,13 @@
 		"test": "vitest --run",
 		"test:watch": "vitest",
 		"update:lockfile": "yarn",
-		"watch": "svelte-kit package -w"
+		"watch": "svelte-package -w"
 	},
 	"devDependencies": {
 		"@babel/core": "7.18.6",
 		"@sveltejs/adapter-auto": "next",
 		"@sveltejs/kit": "next",
+    "@sveltejs/package": "next",
 		"@typescript-eslint/eslint-plugin": "5.27.0",
 		"@typescript-eslint/parser": "5.27.0",
 		"babel-loader": "8.2.5",

--- a/packages/svelteui-composables/svelte.config.js
+++ b/packages/svelteui-composables/svelte.config.js
@@ -14,15 +14,15 @@ const config = {
 		alias: {
 			$clib: 'src'
 		},
-		adapter: adapter(),
-		package: {
-			exports: (filepath) => {
-				if (filepath.endsWith('.d.ts')) return false;
-				return !mm.contains(filepath, '**_');
-			},
-			files: mm.matcher('!**/*.test.{ts, js}')
-		}
-	}
+		adapter: adapter()
+	},
+  package: {
+    exports: (filepath) => {
+      if (filepath.endsWith('.d.ts')) return false;
+      return !mm.contains(filepath, '**_');
+    },
+    files: mm.matcher('!**/*.test.{ts, js}')
+  }
 };
 
 export default config;

--- a/packages/svelteui-core/package.json
+++ b/packages/svelteui-core/package.json
@@ -42,7 +42,7 @@
 		"format": "prettier --write --plugin-search-dir=. .",
 		"generate-types": "deno run --unstable --allow-read --allow-write ../../scripts/generate-types.ts",
 		"lint": "prettier --check --plugin-search-dir=. . && eslint .",
-		"package": "svelte-kit package",
+		"package": "svelte-package",
 		"prepare": "svelte-kit sync",
 		"preview": "vite preview",
 		"pub": "cd package && npm publish",
@@ -51,7 +51,7 @@
 		"test": "vitest --run",
 		"test:watch": "vitest",
 		"update:lockfile": "yarn",
-		"watch": "svelte-kit package -w"
+		"watch": "svelte-package -w"
 	},
 	"dependencies": {
 		"@floating-ui/dom": "0.5.2",
@@ -61,6 +61,7 @@
 		"@babel/core": "7.18.6",
 		"@sveltejs/adapter-auto": "next",
 		"@sveltejs/kit": "next",
+    "@sveltejs/package": "next",
 		"@typescript-eslint/eslint-plugin": "5.27.0",
 		"@typescript-eslint/parser": "5.27.0",
 		"autoprefixer": "10.4.4",

--- a/packages/svelteui-core/svelte.config.js
+++ b/packages/svelteui-core/svelte.config.js
@@ -11,18 +11,18 @@ const config = {
 	kit: {
 		files: {
 			lib: 'src'
-		},
-		package: {
-			exports: (filepath) => {
-				if (filepath.endsWith('.d.ts')) return false;
-				if (filepath.endsWith('.config.js')) return false;
-				if (mm.contains(filepath, 'internal/**')) return false;
-				if (mm.contains(filepath, 'styles/**')) return false;
-				return !mm.contains(filepath, '**_');
-			},
-			files: mm.matcher('!**/*.test.{ts, js}')
 		}
-	}
+	},
+  package: {
+    exports: (filepath) => {
+      if (filepath.endsWith('.d.ts')) return false;
+      if (filepath.endsWith('.config.js')) return false;
+      if (mm.contains(filepath, 'internal/**')) return false;
+      if (mm.contains(filepath, 'styles/**')) return false;
+      return !mm.contains(filepath, '**_');
+    },
+    files: mm.matcher('!**/*.test.{ts, js}')
+  }
 };
 
 export default config;

--- a/packages/svelteui-dates/package.json
+++ b/packages/svelteui-dates/package.json
@@ -43,14 +43,14 @@
 		"format": "prettier --write --plugin-search-dir=. .",
 		"generate-types": "deno run --unstable --allow-read --allow-write ../../scripts/generate-types.ts",
 		"lint": "prettier --check --plugin-search-dir=. . && eslint .",
-		"package": "svelte-kit package",
+		"package": "svelte-package",
 		"prepare": "svelte-kit sync",
 		"preview": "vite preview",
 		"pub": "cd package && npm publish",
 		"sort": "npx sort-package-json",
 		"storybook": "start-storybook -p 6006",
 		"update:lockfile": "yarn",
-		"watch": "svelte-kit package -w"
+		"watch": "svelte-package -w"
 	},
 	"dependencies": {
 		"dayjs": "1.11.1"
@@ -59,6 +59,7 @@
 		"@babel/core": "7.18.6",
 		"@sveltejs/adapter-auto": "next",
 		"@sveltejs/kit": "next",
+    "@sveltejs/package": "next",
 		"@typescript-eslint/eslint-plugin": "5.27.0",
 		"@typescript-eslint/parser": "5.27.0",
 		"autoprefixer": "10.4.4",

--- a/packages/svelteui-dates/svelte.config.js
+++ b/packages/svelteui-dates/svelte.config.js
@@ -17,18 +17,18 @@ const config = {
 	kit: {
 		alias: {
 			$dlib: 'src/lib'
-		},
-		package: {
-			exports: (filepath) => {
-				if (filepath.endsWith('.d.ts')) return false;
-				if (filepath.endsWith('.config.js')) return false;
-				if (mm.contains(filepath, 'internal/**')) return false;
-				if (mm.contains(filepath, 'styles/**')) return false;
-				return !mm.contains(filepath, '**_');
-			},
-			files: mm.matcher('!**/*.test.{ts, js}')
 		}
-	}
+	},
+  package: {
+    exports: (filepath) => {
+      if (filepath.endsWith('.d.ts')) return false;
+      if (filepath.endsWith('.config.js')) return false;
+      if (mm.contains(filepath, 'internal/**')) return false;
+      if (mm.contains(filepath, 'styles/**')) return false;
+      return !mm.contains(filepath, '**_');
+    },
+    files: mm.matcher('!**/*.test.{ts, js}')
+  }
 };
 
 export default config;

--- a/packages/svelteui-demos/package.json
+++ b/packages/svelteui-demos/package.json
@@ -41,13 +41,13 @@
 		"format": "prettier --write --plugin-search-dir=. .",
 		"generate-types": "deno run --unstable --allow-read --allow-write ../../scripts/generate-types.ts",
 		"lint": "prettier --check --plugin-search-dir=. . && eslint .",
-		"package": "svelte-kit package",
+		"package": "svelte-package",
 		"prepare": "svelte-kit sync",
 		"preview": "vite preview",
 		"sort": "npx sort-package-json",
 		"storybook": "start-storybook -p 6006",
 		"update:lockfile": "yarn",
-		"watch": "svelte-kit package -w"
+		"watch": "svelte-package -w"
 	},
 	"dependencies": {
 		"@svelteuidev/composables": "0.7.2",
@@ -60,6 +60,7 @@
 		"@babel/core": "7.18.6",
 		"@sveltejs/adapter-auto": "next",
 		"@sveltejs/kit": "next",
+    "@sveltejs/package": "next",
 		"@typescript-eslint/eslint-plugin": "5.27.0",
 		"@typescript-eslint/parser": "5.27.0",
 		"autoprefixer": "10.4.4",

--- a/packages/svelteui-demos/svelte.config.js
+++ b/packages/svelteui-demos/svelte.config.js
@@ -12,18 +12,16 @@ const config = {
 		generate: 'ssr',
 		hydratable: true
 	},
-	kit: {
-		package: {
-			exports: (filepath) => {
-				if (filepath.endsWith('.d.ts')) return false;
-				if (filepath.endsWith('.config.js')) return false;
-				if (mm.contains(filepath, 'internal/**')) return false;
-				if (mm.contains(filepath, 'styles/**')) return false;
-				return !mm.contains(filepath, '**_');
-			},
-			files: mm.matcher('!**/*.test.{ts, js}')
-		}
-	}
+  package: {
+    exports: (filepath) => {
+      if (filepath.endsWith('.d.ts')) return false;
+      if (filepath.endsWith('.config.js')) return false;
+      if (mm.contains(filepath, 'internal/**')) return false;
+      if (mm.contains(filepath, 'styles/**')) return false;
+      return !mm.contains(filepath, '**_');
+    },
+    files: mm.matcher('!**/*.test.{ts, js}')
+  }
 };
 
 export default config;

--- a/packages/svelteui-motion/package.json
+++ b/packages/svelteui-motion/package.json
@@ -40,7 +40,7 @@
 		"format": "prettier --write --plugin-search-dir=. .",
 		"generate-types": "deno run --unstable --allow-read --allow-write ../../scripts/generate-types.ts",
 		"lint": "prettier --check --plugin-search-dir=. . && eslint .",
-		"package": "svelte-kit package",
+		"package": "svelte-package",
 		"prepare": "svelte-kit sync",
 		"preview": "vite preview",
 		"pub": "cd package && npm publish",
@@ -48,12 +48,13 @@
 		"sort": "npx sort-package-json",
 		"storybook": "start-storybook -p 6006",
 		"update:lockfile": "yarn",
-		"watch": "svelte-kit package -w"
+		"watch": "svelte-package -w"
 	},
 	"devDependencies": {
 		"@babel/core": "7.18.6",
 		"@sveltejs/adapter-auto": "next",
 		"@sveltejs/kit": "next",
+    "@sveltejs/package": "next",
 		"@typescript-eslint/eslint-plugin": "5.27.0",
 		"@typescript-eslint/parser": "5.27.0",
 		"babel-loader": "8.2.5",

--- a/packages/svelteui-motion/svelte.config.js
+++ b/packages/svelteui-motion/svelte.config.js
@@ -6,16 +6,13 @@ const config = {
 	// Consult https://github.com/sveltejs/svelte-preprocess
 	// for more information about preprocessors
 	preprocess: preprocess(),
-
-	kit: {
-		package: {
-			exports: (filepath) => {
-				if (filepath.endsWith('.d.ts')) return false;
-				return !mm.contains(filepath, '**_');
-			},
-			files: mm.matcher('!**/*.test.{ts, js}')
-		}
-	}
+  package: {
+    exports: (filepath) => {
+      if (filepath.endsWith('.d.ts')) return false;
+      return !mm.contains(filepath, '**_');
+    },
+    files: mm.matcher('!**/*.test.{ts, js}')
+  }
 };
 
 export default config;

--- a/packages/svelteui-preprocessors/package.json
+++ b/packages/svelteui-preprocessors/package.json
@@ -38,14 +38,14 @@
 		"format": "prettier --write --plugin-search-dir=. .",
 		"generate-types": "deno run --unstable --allow-read --allow-write ../../scripts/generate-types.ts",
 		"lint": "prettier --check --plugin-search-dir=. . && eslint .",
-		"package": "svelte-kit package",
+		"package": "svelte-package",
 		"prepare": "svelte-kit sync",
 		"preview": "vite preview",
 		"pub": "cd package && npm publish",
 		"sort": "npx sort-package-json",
 		"storybook": "start-storybook -p 6006",
 		"update:lockfile": "yarn",
-		"watch": "svelte-kit package -w"
+		"watch": "svelte-package -w"
 	},
 	"devDependencies": {
 		"@babel/core": "7.18.6",
@@ -53,6 +53,7 @@
 		"@sveltejs/adapter-auto": "next",
 		"@sveltejs/adapter-node": "next",
 		"@sveltejs/kit": "next",
+    "@sveltejs/package": "next",
 		"@testing-library/svelte": "3.1.2",
 		"@types/js-string-escape": "1.0.1",
 		"@types/mkdirp": "1.0.2",

--- a/packages/svelteui-preprocessors/svelte.config.js
+++ b/packages/svelteui-preprocessors/svelte.config.js
@@ -14,18 +14,16 @@ const config = {
 			plugins: [autoprefixer(), cssnano()]
 		}
 	}),
-	kit: {
-		package: {
-			exports: (filepath) => {
-				if (filepath.endsWith('.d.ts')) return false;
-				if (filepath.endsWith('.config.js')) return false;
-				if (mm.contains(filepath, 'internal/**')) return false;
-				if (mm.contains(filepath, 'styles/**')) return false;
-				return !mm.contains(filepath, '**_');
-			},
-			files: mm.matcher('!**/*.test.{ts, js}')
-		}
-	}
+  package: {
+    exports: (filepath) => {
+      if (filepath.endsWith('.d.ts')) return false;
+      if (filepath.endsWith('.config.js')) return false;
+      if (mm.contains(filepath, 'internal/**')) return false;
+      if (mm.contains(filepath, 'styles/**')) return false;
+      return !mm.contains(filepath, '**_');
+    },
+    files: mm.matcher('!**/*.test.{ts, js}')
+  }
 };
 
 export default config;

--- a/packages/svelteui-prism/package.json
+++ b/packages/svelteui-prism/package.json
@@ -41,7 +41,7 @@
 		"format": "prettier --write --plugin-search-dir=. .",
 		"generate-types": "deno run --unstable --allow-read --allow-write ../../scripts/generate-types.ts",
 		"lint": "prettier --check --plugin-search-dir=. . && eslint .",
-		"package": "svelte-kit package",
+		"package": "svelte-package",
 		"prepare": "svelte-kit sync",
 		"preview": "vite preview",
 		"pub": "cd package && npm publish",
@@ -49,7 +49,7 @@
 		"sort": "npx sort-package-json",
 		"storybook": "start-storybook -p 6006",
 		"update:lockfile": "yarn",
-		"watch": "svelte-kit package -w"
+		"watch": "svelte-package -w"
 	},
 	"dependencies": {
 		"prism-svelte": "0.5.0",
@@ -59,6 +59,7 @@
 		"@babel/core": "7.18.6",
 		"@sveltejs/adapter-auto": "next",
 		"@sveltejs/kit": "next",
+    "@sveltejs/package": "next",
 		"@types/prismjs": "1.26.0",
 		"@typescript-eslint/eslint-plugin": "5.27.0",
 		"@typescript-eslint/parser": "5.27.0",

--- a/packages/svelteui-prism/svelte.config.js
+++ b/packages/svelteui-prism/svelte.config.js
@@ -10,15 +10,13 @@ const config = {
 		generate: 'ssr',
 		hydratable: true
 	},
-	kit: {
-		package: {
-			exports: (filepath) => {
-				if (filepath.endsWith('.d.ts')) return false;
-				return !mm.contains(filepath, '**_');
-			},
-			files: mm.matcher('!**/*.test.{ts, js}')
-		}
-	}
+  package: {
+    exports: (filepath) => {
+      if (filepath.endsWith('.d.ts')) return false;
+      return !mm.contains(filepath, '**_');
+    },
+    files: mm.matcher('!**/*.test.{ts, js}')
+  }
 };
 
 export default config;

--- a/packages/svelteui-tests/package.json
+++ b/packages/svelteui-tests/package.json
@@ -35,18 +35,19 @@
 		"format": "prettier --write --plugin-search-dir=. .",
 		"generate-types": "deno run --unstable --allow-read --allow-write ../../scripts/generate-types.ts",
 		"lint": "prettier --check --plugin-search-dir=. . && eslint .",
-		"package": "svelte-kit package",
+		"package": "svelte-package",
 		"prepare": "svelte-kit sync",
 		"preview": "vite preview",
 		"sort": "npx sort-package-json",
 		"storybook": "start-storybook -p 6006",
 		"update:lockfile": "yarn",
-		"watch": "svelte-kit package -w"
+		"watch": "svelte-package -w"
 	},
 	"devDependencies": {
 		"@babel/core": "7.18.6",
 		"@sveltejs/adapter-auto": "next",
 		"@sveltejs/kit": "next",
+    "@sveltejs/package": "next",
 		"@testing-library/svelte": "3.1.1",
 		"@typescript-eslint/eslint-plugin": "5.27.0",
 		"@typescript-eslint/parser": "5.27.0",

--- a/packages/svelteui-tests/svelte.config.js
+++ b/packages/svelteui-tests/svelte.config.js
@@ -16,15 +16,13 @@ const config = {
 		generate: 'ssr',
 		hydratable: true
 	},
-	kit: {
-		package: {
-			exports: (filepath) => {
-				if (filepath.endsWith('.d.ts')) return false;
-				return !mm.contains(filepath, '**_');
-			},
-			files: mm.matcher('!**/*.test.{ts, js}')
-		}
-	}
+  package: {
+    exports: (filepath) => {
+      if (filepath.endsWith('.d.ts')) return false;
+      return !mm.contains(filepath, '**_');
+    },
+    files: mm.matcher('!**/*.test.{ts, js}')
+  }
 };
 
 export default config;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2690,6 +2690,16 @@
     tiny-glob "^0.2.9"
     undici "^5.8.1"
 
+"@sveltejs/package@next":
+  version "1.0.0-next.1"
+  resolved "https://registry.yarnpkg.com/@sveltejs/package/-/package-1.0.0-next.1.tgz#6a724bc42a218dcc024e105fe370939b1eab754f"
+  integrity sha512-U8XBk6Cfy8MjKG41Uyo+fqBpdhu7xUSnhiCNoODRaAtWV02RZoLh+McXrsxEvqi/ycgymctlhJhssqDnD+E+FA==
+  dependencies:
+    chokidar "^3.5.3"
+    kleur "^4.1.4"
+    sade "^1.8.1"
+    svelte2tsx "~0.5.10"
+
 "@sveltejs/vite-plugin-svelte@^1.0.1":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.2.tgz#d9997e9f1aeca7b5f72634e774c4f0c7207134b3"
@@ -4723,7 +4733,7 @@ check-error@^1.0.2:
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
   integrity sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==
 
-"chokidar@>=3.0.0 <4.0.0", chokidar@^3.4.1, chokidar@^3.4.2, chokidar@^3.5.0:
+"chokidar@>=3.0.0 <4.0.0", chokidar@^3.4.1, chokidar@^3.4.2, chokidar@^3.5.0, chokidar@^3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
   integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
@@ -13139,6 +13149,14 @@ svelte2tsx@0.5.7:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/svelte2tsx/-/svelte2tsx-0.5.7.tgz#6d462461d5f109eba7ad2d23d3d4c2cf5337545f"
   integrity sha512-rekPWR5at7DNvIlJRSCyKFZ6Go/KyqjDRL/zRWQSNMbvTIocsm/gDtSbLz64ZP5Qz3tUeod7QzDqX13lF60kCg==
+  dependencies:
+    dedent-js "^1.0.1"
+    pascal-case "^3.1.1"
+
+svelte2tsx@~0.5.10:
+  version "0.5.14"
+  resolved "https://registry.yarnpkg.com/svelte2tsx/-/svelte2tsx-0.5.14.tgz#f22cb8dd349266b4125876fbce0fa4a314b678a8"
+  integrity sha512-/9hGkIUMVwZDJoERS6k1x+y6Ir+PpkxbL/UWQ2+RhK/PwUoIaDTCfw79/H1bgYNUTr/7ZaYanJGPuaWARNbbyQ==
   dependencies:
     dedent-js "^1.0.1"
     pascal-case "^3.1.1"


### PR DESCRIPTION
Command `svelte-kit package` was deprecated in favor of a new package `@sveltejs/package` and script `svelte-package`. This PR contains this migration.

Links:
* https://kit.svelte.dev/docs/packaging
* https://github.com/sveltejs/kit/pull/5730

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `yarn lint` or just run `yarn repo:prepush` and check to see if it's passing.
