### PR TITLE
[docs]: improve Modal target warning and demo

### DIFF
--- a/apps/docs/src/pages/core/modal.md
+++ b/apps/docs/src/pages/core/modal.md
@@ -11,15 +11,21 @@ docs: 'core/modal.md'
 ---
 
 <script>
+	import { Alert, Text } from '@svelteuidev/core';
 	import { Demo, ModalDemos } from '@svelteuidev/demos';
-  	import { Heading } from 'components';
+  import { InfoCircled } from 'radix-icons-svelte';
+  import { Heading } from 'components';
 </script>
 
 <Heading />
 
 ## Usage
 
-When using the Modal component it's important that you wrap your app in the [SvelteUIProvider](theming/svelteui-provider). If you for some reason don't want to do that, you must change the `target` prop to something else. Such as <code>{"target={'body'}"}</code>.
+<Alert icon={InfoCircled} title="Important!" color='blue' override={{ marginBottom: '16px' }}>
+  <Text override={{ lineHeight: '1.6' }}>
+    When using the Modal component it's important that you wrap your app in the <a href='theming/svelteui-provider'>SvelteUIProvider</a>. If for some reason you don't want to do that, you must change the <code>target</code> prop to something else. Such as <code>{"target={'body'}"}</code>.
+  </Text>
+</Alert>
 
 <Demo demo={ModalDemos.usage} />
 

--- a/packages/svelteui-demos/src/lib/demos/core/Modal/Modal.demo.usage.svelte
+++ b/packages/svelteui-demos/src/lib/demos/core/Modal/Modal.demo.usage.svelte
@@ -7,6 +7,8 @@
 	let opened = false;
 <\/script>
 
+<!-- This component must be wrapped in SvelteUIProvider (on the application level)
+  or you must specify a target with the target prop --!>
 <Modal {opened} on:close={closeModal} title="Introduce yourself!">
 	<!-- Modal Content -->
 </Modal>


### PR DESCRIPTION
Since it is the most common question/doubt asked in Discord, perhaps it is best if we improve the `target` warning for Modal so that people that are using the demos examples can quickly see what is missing from the setup.
 
Now:<br>
<img width="1706" alt="image" src="https://user-images.githubusercontent.com/25725586/187439311-37407769-7b10-4f27-b14a-a2fb1d3c3801.png">

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `yarn lint` or just run `yarn repo:prepush` and check to see if it's passing.
