### PR TITLE
[@svelteui/core]: fix Tab dark mode color and simple story for testing

### DIFF
--- a/packages/svelteui-core/src/components/Tabs/Tab/Tab.styles.ts
+++ b/packages/svelteui-core/src/components/Tabs/Tab/Tab.styles.ts
@@ -28,9 +28,6 @@ export const getVariantStyles = (
 			transition: 'border-color 150ms ease, color 150ms ease',
 			color: theme.colors.black.value,
 			[orientation === 'horizontal' ? 'borderBottom' : 'borderRight']: '2px solid transparent',
-			darkMode: {
-				color: theme.fn.themeColor('dark', 0)
-			},
 			'&.active': {
 				color: theme.fn.themeColor(color, 7),
 				[orientation === 'horizontal' ? 'borderBottomColor' : 'borderRightColor']:
@@ -50,9 +47,6 @@ export const getVariantStyles = (
 			borderBottom: orientation === 'horizontal' ? '0' : '1px solid transparent',
 			borderRight: orientation === 'vertical' ? '0' : '1px solid transparent',
 			color: theme.fn.themeColor('gray', 7),
-			darkMode: {
-				color: theme.fn.themeColor('dark', 1)
-			},
 			'&.active': {
 				color: theme.colors.black.value,
 				borderColor: theme.fn.themeColor('gray', 2),
@@ -72,9 +66,6 @@ export const getVariantStyles = (
 			height: 'auto',
 			padding: `${theme.space.xsPX} ${theme.space.lgPX}`,
 			fontWeight: '500',
-			darkMode: {
-				color: theme.fn.themeColor('dark', 1)
-			},
 			'&:hover': {
 				background: theme.fn.themeColor('gray', 0),
 				darkMode: {
@@ -106,6 +97,9 @@ export default createStyles((theme, { color, orientation }: TabStyleParams) => {
 			fontSize: theme.fontSizes.sm,
 			cursor: 'pointer',
 			width: orientation === 'vertical' ? '100%' : 'auto',
+			darkMode: {
+				color: theme.colors.white.value
+			},
 			...getVariantStyles(color, orientation, theme),
 			'&:disabled': {
 				cursor: 'not-allowed',

--- a/packages/svelteui-core/src/components/Tabs/Tabs.stories.svelte
+++ b/packages/svelteui-core/src/components/Tabs/Tabs.stories.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { Meta, Template, Story } from '@storybook/addon-svelte-csf';
+	import { Camera, EnvelopeClosed, Gear } from 'radix-icons-svelte';
+	import { Tabs } from './index';
+</script>
+
+<Meta title="Components/Tabs" component={Tabs} />
+
+<Template let:args>
+	<Tabs {...args}>
+		<Tabs.Tab label="Gallery" icon={Camera}>Gallery tab content</Tabs.Tab>
+		<Tabs.Tab label="Messages" icon={EnvelopeClosed}>Messages tab content</Tabs.Tab>
+		<Tabs.Tab label="Settings" icon={Gear}>Settings tab content</Tabs.Tab>
+	</Tabs>
+</Template>
+
+<Story name="Tabs" id="tabs" />


### PR DESCRIPTION
Fixed mentioned problem in Discord - https://discord.com/channels/954790377754337280/959831408988266506/1015295779117740112 - where the tabs text would not adapt to dark mode.

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `yarn lint` or just run `yarn repo:prepush` and check to see if it's passing.
