### PR TITLE
[core]: fix prettier path to not apply changes in package.json peer dependencies

### DIFF
--- a/packages/svelteui-composables/package.json
+++ b/packages/svelteui-composables/package.json
@@ -41,7 +41,7 @@
 		"check:watch": "svelte-check --tsconfig ./tsconfig.json --watch",
 		"coverage": "vitest run --coverage",
 		"dev": "vite dev",
-		"format": "prettier --write --plugin-search-dir=. .",
+		"format": "prettier --write --plugin-search-dir=. src/",
 		"generate-types": "deno run --unstable --allow-read --allow-write ../../scripts/generate-types.ts",
 		"lint": "prettier --check --plugin-search-dir=. . && eslint .",
 		"package": "svelte-package",

--- a/packages/svelteui-core/package.json
+++ b/packages/svelteui-core/package.json
@@ -39,7 +39,7 @@
 		"check": "svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-check --tsconfig ./tsconfig.json --watch",
 		"dev": "vite dev",
-		"format": "prettier --write --plugin-search-dir=. .",
+		"format": "prettier --write --plugin-search-dir=. src/",
 		"generate-types": "deno run --unstable --allow-read --allow-write ../../scripts/generate-types.ts",
 		"lint": "prettier --check --plugin-search-dir=. . && eslint .",
 		"package": "svelte-package",

--- a/packages/svelteui-dates/package.json
+++ b/packages/svelteui-dates/package.json
@@ -40,7 +40,7 @@
 		"check": "svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-check --tsconfig ./tsconfig.json --watch",
 		"dev": "vite dev",
-		"format": "prettier --write --plugin-search-dir=. .",
+		"format": "prettier --write --plugin-search-dir=. src/",
 		"generate-types": "deno run --unstable --allow-read --allow-write ../../scripts/generate-types.ts",
 		"lint": "prettier --check --plugin-search-dir=. . && eslint .",
 		"package": "svelte-package",

--- a/packages/svelteui-demos/package.json
+++ b/packages/svelteui-demos/package.json
@@ -38,7 +38,7 @@
 		"check": "svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-check --tsconfig ./tsconfig.json --watch",
 		"dev": "vite dev",
-		"format": "prettier --write --plugin-search-dir=. .",
+		"format": "prettier --write --plugin-search-dir=. src/",
 		"generate-types": "deno run --unstable --allow-read --allow-write ../../scripts/generate-types.ts",
 		"lint": "prettier --check --plugin-search-dir=. . && eslint .",
 		"package": "svelte-package",

--- a/packages/svelteui-motion/package.json
+++ b/packages/svelteui-motion/package.json
@@ -37,7 +37,7 @@
 		"check": "svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-check --tsconfig ./tsconfig.json --watch",
 		"dev": "vite dev",
-		"format": "prettier --write --plugin-search-dir=. .",
+		"format": "prettier --write --plugin-search-dir=. src/",
 		"generate-types": "deno run --unstable --allow-read --allow-write ../../scripts/generate-types.ts",
 		"lint": "prettier --check --plugin-search-dir=. . && eslint .",
 		"package": "svelte-package",

--- a/packages/svelteui-preprocessors/package.json
+++ b/packages/svelteui-preprocessors/package.json
@@ -35,7 +35,7 @@
 		"check": "svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-check --tsconfig ./tsconfig.json --watch",
 		"dev": "vite dev",
-		"format": "prettier --write --plugin-search-dir=. .",
+		"format": "prettier --write --plugin-search-dir=. src/",
 		"generate-types": "deno run --unstable --allow-read --allow-write ../../scripts/generate-types.ts",
 		"lint": "prettier --check --plugin-search-dir=. . && eslint .",
 		"package": "svelte-package",

--- a/packages/svelteui-tests/package.json
+++ b/packages/svelteui-tests/package.json
@@ -32,7 +32,7 @@
 		"check": "svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-check --tsconfig ./tsconfig.json --watch",
 		"dev": "vite dev",
-		"format": "prettier --write --plugin-search-dir=. .",
+		"format": "prettier --write --plugin-search-dir=. src/",
 		"generate-types": "deno run --unstable --allow-read --allow-write ../../scripts/generate-types.ts",
 		"lint": "prettier --check --plugin-search-dir=. . && eslint .",
 		"package": "svelte-package",


### PR DESCRIPTION
**Problem:** Running `yarn format` changed the package.json - removing the `>=` from the svelte peerDependency, which causes errors when installing svelteui

**Solution:** Do not run prettier in package.json files, only in src/ files

Related to https://github.com/svelteuidev/svelteui/issues/205

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `yarn lint` or just run `yarn repo:prepush` and check to see if it's passing.
