### PR TITLE
[docs] README documentation for NPM package

### DIFF
--- a/packages/svelteui-core/README.md
+++ b/packages/svelteui-core/README.md
@@ -1,19 +1,40 @@
-<p align="center">
-  <h1 align="center">Storybook SvelteKit Typescript starter</h1>
-  <h3 align="center">This is a project that will get your storybook setup's up and running with no headache 😁.</h3>
-</p>
+<center>
+  <h1 align="center">SvelteUI</h1>
+
+[![TypeScript](https://badges.frapsoft.com/typescript/code/typescript.svg?v=101)](https://github.com/ellerbrock/typescript-badges/)
+
+</center>
+
+SvelteUI is a Svelte library (heavily inspired by but not affiliated with Mantine) with a variety of packages to help make development easier! This library not only aims to be more than just a component library, but one that fits all the needs of a project. SvelteUI aims to take care of the boring and complicated stuff for you so that you can start building quickly.
+
+Instead of remaking the same components, recreating custom actions, transitions, utilities, etc. SvelteUI is designed so you can start making projects quickly. It works amazingly well out-of-the-box, with zero-configuration, and can be customized to your liking as your application grows.
+
+# Features
+ - SvelteKit and SSR Compatible
+ - TypeScript and type definitions are supported, but optional.
+ - All components are accessible according to WAI-ARIA standards.
+ - Dark theme included, as well as a custom theming api.
+ - Highly customizable
+ - Minimal to no third-party dependency usage.
+ - Easy setup - Zero Configuration
 
 # Installation
-
-This is a template repo, so just click the button that says use this template
+See https://www.svelteui.org/installation for complete guide.
+```
+npm i @svelteuidev/core @svelteuidev/composables
+```
 
 # Project Configuration
+Wrap your app in the `SvelteUIProvider` component for more theming options, such as dark theme.
+```svelte
+<script>
+    import { SvelteUIProvider } from '@svelteuidev/core';
+</script>
 
-> Guides will be written later on integrating other tools (tailwind, postcss, etc.)
-
-# Contributing
-
-Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
+<SvelteUIProvider>
+    <YourApp />
+</SvelteUIProvider>
+```
 
 # License
 

--- a/packages/svelteui-core/src/components/Menu/Menu.stories.svelte
+++ b/packages/svelteui-core/src/components/Menu/Menu.stories.svelte
@@ -7,6 +7,8 @@
   import { Center } from '../Center';
   import { SimpleGrid } from '../SimpleGrid';
 	import { Camera, ChatBubble, Gear, MagnifyingGlass, Trash, Width } from 'radix-icons-svelte';
+
+  let menuEvents = []
 </script>
 
 <Meta title="Components/Menu" component={Menu} />
@@ -89,4 +91,17 @@
       </Menu>
     </Center>
   </SimpleGrid>
+</Story>
+
+<Story name="Event listeners">
+  <Button on:click={()=>menuEvents = [...menuEvents, 'button click']}>Test event</Button>
+  <Menu on:open={()=>menuEvents = [...menuEvents, 'opened']} on:close={()=>menuEvents = [...menuEvents, 'closed']}>
+    <Button slot="control">Toggle menu</Button>
+    <Menu.Item icon={Gear}>Settings</Menu.Item>
+  </Menu>
+  <ol>
+    {#each menuEvents as event}
+      <li>{event}</li>
+    {/each}
+  </ol>
 </Story>


### PR DESCRIPTION
The NPM package page had a template README, which made the package look like its not ready for use. 

See https://www.npmjs.com/package/@svelteuidev/core .

I have written some basic info in the README. This will at least help first time users and direct them to the website.

