### PR TITLE
[@svelteui/core]: Add IconRenderer to various components that support `HTMLOrSVGElement` icon prop

### DIFF
--- a/packages/svelteui-core/src/components/Alert/Alert.svelte
+++ b/packages/svelteui-core/src/components/Alert/Alert.svelte
@@ -4,6 +4,7 @@
 	import { Box } from '../Box';
 	import { CloseButton } from '../ActionIcon';
 	import type { AlertProps as $$AlertProps } from './Alert.styles';
+	import IconRenderer from '../IconRenderer/IconRenderer.svelte';
 
 	interface $$Props extends $$AlertProps {}
 
@@ -34,7 +35,7 @@
 <Box {use} bind:element role="alert" class={cx(className, variant, classes.root)} {...$$restProps}>
 	<div class={classes.wrapper}>
 		{#if icon}
-			<svelte:component this={icon} class={classes.icon} {...iconProps} />
+			<IconRenderer {icon} className={classes.icon} {iconSize} {...iconProps} />
 		{/if}
 
 		<div class={classes.content}>

--- a/packages/svelteui-core/src/components/IconRenderer/IconRenderer.stories.svelte
+++ b/packages/svelteui-core/src/components/IconRenderer/IconRenderer.stories.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+	import { Meta, Story, Template } from '@storybook/addon-svelte-csf';
+	import { InfoCircled } from 'radix-icons-svelte';
+	import IconRenderer from './IconRenderer.svelte';
+
+	const iconSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+	const iconPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+
+	iconSvg.setAttribute('fill', 'none');
+	iconSvg.setAttribute('viewBox', '0 0 24 24');
+	iconSvg.setAttribute('stroke', 'currentColor');
+	iconSvg.classList.add('post-icon');
+
+	iconPath.setAttribute(
+		'd',
+		'M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1'
+	);
+	iconPath.setAttribute('stroke-linecap', 'round');
+	iconPath.setAttribute('stroke-linejoin', 'round');
+	iconPath.setAttribute('stroke-width', '2');
+
+	iconSvg.appendChild(iconPath);
+</script>
+
+<Meta
+	title="Components/IconRenderer"
+	component={IconRenderer}
+	argTypes={{
+		icon: {
+			control: false
+		},
+		iconSize: {
+			control: 'number'
+		}
+	}}
+/>
+
+<Template let:args>
+	<span>Svelte component</span>
+	<IconRenderer {...args} icon={InfoCircled} />
+	<br />
+	<span>SVG element</span>
+	<IconRenderer {...args} icon={iconSvg} />
+</Template>
+
+<Story
+	name="Default"
+	args={{
+		iconSize: 16
+	}}
+/>

--- a/packages/svelteui-core/src/components/IconRenderer/IconRenderer.styles.ts
+++ b/packages/svelteui-core/src/components/IconRenderer/IconRenderer.styles.ts
@@ -1,0 +1,46 @@
+import type { Component } from '$lib/internal';
+import { createStyles, type DefaultProps, type SvelteUINumberSize } from '$lib/styles';
+
+export interface IconRendererProps extends DefaultProps<HTMLOrSVGElement> {
+	icon?: Component | HTMLOrSVGElement;
+	iconSize?: number;
+	iconProps?: Record<string, unknown>;
+}
+
+export interface IconRendererStylesParams {
+	iconSize: SvelteUINumberSize;
+}
+
+export default createStyles((_, { iconSize }: IconRendererStylesParams) => {
+	return {
+		root: {
+			focusRing: 'auto',
+			position: 'relative',
+			appearance: 'none',
+			WebkitAppearance: 'none',
+			WebkitTapHighlightColor: 'transparent',
+			boxSizing: 'border-box',
+			height: `${iconSize}px`,
+			minHeight: `${iconSize}px`,
+			width: `${iconSize}px`,
+			minWidth: `${iconSize}px`,
+			padding: 0,
+			lineHeight: 1,
+			display: 'flex',
+			alignItems: 'center',
+			justifyContent: 'center',
+			cursor: 'pointer',
+			textDecoration: 'none'
+		},
+		icon: {
+			height: `${iconSize}px`,
+			minHeight: `${iconSize}px`,
+			position: 'static',
+			margin: 0,
+			ml: 0,
+			mr: 0,
+			mt: 0,
+			mb: 0
+		}
+	};
+});

--- a/packages/svelteui-core/src/components/IconRenderer/IconRenderer.svelte
+++ b/packages/svelteui-core/src/components/IconRenderer/IconRenderer.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+	import type { IconRendererProps as $$IconRendererProps } from './IconRenderer.styles';
+	import useStyles from './IconRenderer.styles';
+
+	interface $$Props extends $$IconRendererProps {}
+
+	export let className: $$Props['className'] = '',
+		override: $$Props['override'] = {},
+		icon: $$Props['icon'] = undefined,
+		iconSize: $$Props['iconSize'] = 16,
+		iconProps: $$Props['iconProps'] = {};
+
+	$: ({ cx, getStyles, classes } = useStyles({ iconSize }));
+
+	$: if (icon instanceof HTMLElement || icon instanceof SVGElement) {
+		icon.classList.add(classes.icon);
+	}
+</script>
+
+{#if typeof icon === 'function'}
+	<svelte:component
+		this={icon}
+		class={cx(className, getStyles({ css: override }))}
+		{...iconProps}
+	/>
+{:else if icon instanceof HTMLElement || icon instanceof SVGElement}
+	<span class={cx(className, getStyles({ css: override }))}>
+		{@html icon.outerHTML}
+	</span>
+{/if}

--- a/packages/svelteui-core/src/components/IconRenderer/IconRendererUsage.stories.svelte
+++ b/packages/svelteui-core/src/components/IconRenderer/IconRendererUsage.stories.svelte
@@ -1,0 +1,93 @@
+<script lang="ts">
+	import { Meta, Story, Template } from '@storybook/addon-svelte-csf';
+	import { InfoCircled } from 'radix-icons-svelte';
+	import Alert from '../Alert/Alert.svelte';
+	import Button from '../Button/Button.svelte';
+	import Input from '../Input/Input.svelte';
+	import Menu from '../Menu/Menu.svelte';
+	import MenuItem from '../Menu/MenuItem/MenuItem.svelte';
+	import Notification from '../Notification/Notification.svelte';
+	import Tab from '../Tabs/Tab/Tab.svelte';
+	import Tabs from '../Tabs/Tabs.svelte';
+	import IconRenderer from './IconRenderer.svelte';
+
+	const iconSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+	const iconPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+
+	iconSvg.setAttribute('fill', 'none');
+	iconSvg.setAttribute('viewBox', '0 0 24 24');
+	iconSvg.setAttribute('stroke', 'currentColor');
+	iconSvg.classList.add('post-icon');
+
+	iconPath.setAttribute(
+		'd',
+		'M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1'
+	);
+	iconPath.setAttribute('stroke-linecap', 'round');
+	iconPath.setAttribute('stroke-linejoin', 'round');
+	iconPath.setAttribute('stroke-width', '2');
+
+	iconSvg.appendChild(iconPath);
+</script>
+
+<Meta
+	title="Components/IconRenderer/Usage"
+	component={IconRenderer}
+	parameters={{
+		controls: {
+			exclude: /.*/g,
+			hideNoControlsWarning: true
+		}
+	}}
+/>
+
+<Story name="Alert">
+	<Alert icon={InfoCircled} title="Example 1">
+		This alert uses a Svelte component for it's icon
+	</Alert>
+	<br />
+	<Alert icon={iconSvg} title="Example 2">This alert uses an SVG element for it's icon</Alert>
+</Story>
+
+<Story name="Button">
+	<Button>
+		<IconRenderer slot="leftIcon" icon={InfoCircled} />
+		Button with Svelte component icon
+	</Button>
+	<br />
+	<Button>
+		<IconRenderer slot="leftIcon" icon={iconSvg} />
+		Button with SVG icon
+	</Button>
+</Story>
+
+<Story name="Input">
+	<Input icon={InfoCircled} placeholder="Search" />
+	<br />
+	<Input icon={iconSvg} placeholder="Search" />
+</Story>
+
+<Story name="MenuItem">
+	<Menu>
+		<div slot="control">Click Me</div>
+		<MenuItem icon={InfoCircled}>Svelte component</MenuItem>
+		<MenuItem icon={iconSvg}>SVG Element</MenuItem>
+	</Menu>
+</Story>
+
+<Story name="Notification">
+	<Notification title="Svelte Component" icon={InfoCircled}>
+		A notification with an Svelte component icon
+	</Notification>
+	<br />
+	<Notification title="SVG element" icon={iconSvg}>
+		A notification with an SVG element icon
+	</Notification>
+</Story>
+
+<Story name="Tabs">
+	<Tabs>
+		<Tab label="Svelte Component" icon={InfoCircled}>A tab with an Svelte component icon</Tab>
+		<Tab label="SVG element" icon={iconSvg}>A tab with an SVG element icon</Tab>
+	</Tabs>
+</Story>

--- a/packages/svelteui-core/src/components/IconRenderer/index.ts
+++ b/packages/svelteui-core/src/components/IconRenderer/index.ts
@@ -1,0 +1,1 @@
+export { default as IconRenderer } from './IconRenderer.svelte';

--- a/packages/svelteui-core/src/components/Input/Input.svelte
+++ b/packages/svelteui-core/src/components/Input/Input.svelte
@@ -4,6 +4,7 @@
 	import { get_current_component } from 'svelte/internal';
 	import Box from '../Box/Box.svelte';
 	import type { InputProps as $$InputProps } from './Input.styles';
+	import IconRenderer from '../IconRenderer/IconRenderer.svelte';
 
 	interface $$Props extends $$InputProps {}
 
@@ -87,12 +88,7 @@ Base component to create custom inputs
 
 <Box {...wrapperProps} class={getStyles({ css: override })} {...$$restProps}>
 	{#if icon}
-		<svelte:component
-			this={icon}
-			size={iconProps.size}
-			color={iconProps.color}
-			class={classes.icon}
-		/>
+		<IconRenderer {icon} className={classes.icon} {...iconProps} iconSize={16} />
 	{/if}
 	{#if isHTMLElement && root === 'input'}
 		<input

--- a/packages/svelteui-core/src/components/Menu/MenuItem/MenuItem.svelte
+++ b/packages/svelteui-core/src/components/Menu/MenuItem/MenuItem.svelte
@@ -8,6 +8,7 @@
 	import type { Writable } from 'svelte/store';
 	import type { MenuContextValue } from '../Menu.context';
 	import type { MenuItemProps as $$MenuItemProps } from './MenuItem.styles';
+	import IconRenderer from '../../IconRenderer/IconRenderer.svelte';
 
 	interface $$Props extends $$MenuItemProps {}
 
@@ -52,7 +53,7 @@
 >
 	<div class={classes.itemInner}>
 		{#if icon}
-			<svelte:component this={icon} class={classes.itemIcon} {...iconProps} />
+			<IconRenderer {icon} className={classes.itemIcon} {...iconProps} />
 		{/if}
 		<div class={classes.itemBody}>
 			<div class={classes.itemLabel}>

--- a/packages/svelteui-core/src/components/Notification/Notification.svelte
+++ b/packages/svelteui-core/src/components/Notification/Notification.svelte
@@ -6,6 +6,7 @@
 	import { Loader } from '../Loader';
 	import { Text } from '../Text';
 	import type { NotificationProps as $$NotificationProps } from './Notification.styles';
+	import IconRenderer from '../IconRenderer/IconRenderer.svelte';
 
 	interface $$Props extends $$NotificationProps {}
 
@@ -45,8 +46,8 @@
 	{...$$restProps}
 >
 	{#if icon && !loading}
-		<slot class={classes.icon} name="icon">
-			<svelte:component this={icon} class={classes.icon} {...iconProps} />
+		<slot name="icon">
+			<IconRenderer {icon} className={classes.icon} {...iconProps} />
 		</slot>
 	{/if}
 	{#if loading}

--- a/packages/svelteui-core/src/components/Tabs/Tab/Tab.svelte
+++ b/packages/svelteui-core/src/components/Tabs/Tab/Tab.svelte
@@ -5,6 +5,7 @@
 	import { getContext, onMount } from 'svelte';
 	import type { TabsContext } from '../Tabs.styles';
 	import type { TabProps as $$TabProps } from './Tab.styles';
+	import IconRenderer from '$lib/components/IconRenderer/IconRenderer.svelte';
 
 	interface $$Props extends $$TabProps {}
 
@@ -60,7 +61,7 @@
 >
 	<div class={classes.inner}>
 		{#if icon}
-			<svelte:component this={icon} class={classes.icon} />
+			<IconRenderer {icon} className={classes.icon} />
 		{/if}
 		{#if label}
 			<div class={classes.label}>{label}</div>


### PR DESCRIPTION
The goal of this MR is to fill a gap of a piece of functionality that seems to be missing.

Currently in SvelteUI, multiple components that take a `icon` prop accept this as either a `Component` (a `SvelteComponentDev` type wrapper) or as a `HTMLOrSVGElement`. However, if a variable of type `HTMLOrSVGElement` is passed to one of these components, an error is returned as the icon is rendered using `<svelte:component/>`.

This MR adds a wrapper component called `IconRenderer` that is used in these various components and will check the type of the `icon` prop and then render it accordingly.

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [x] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.

### Tests

- [x] Run the tests with `npm test` and lint the project with `yarn lint` or just run `yarn repo:prepush` and check to see if it's passing.
