### PR TITLE
[docs]: Fixed the closing tag in an example of classes

### DIFF
--- a/apps/docs/src/pages/basics.md
+++ b/apps/docs/src/pages/basics.md
@@ -139,7 +139,7 @@ All components support a class prop which is useful for things like global styli
     import { Button } from "@svelteuidev/core";
 </script>
 
-<Button class='animation-bounce'>I have a tailwind animation<Button>
+<Button class='animation-bounce'>I have a tailwind animation</Button>
 ```
 
 <BottomNav both slug={{ prev: 'installation', next: 'contributing' }} title={{ prev: 'Installation', next: 'Contributing' }} group={{ prev: 'Getting Started', next: 'Getting Started' }} />


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [x] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.

### Tests

- [ ] Run the tests with `npm test` and lint the project with `yarn lint` or just run `yarn repo:prepush` and check to see if it's passing.

In the classes section of the "Learn the Basics" page, the <Button> component in the example is incorrectly closed and this fixes it.
