### PR TITLE
[docs] fix #226 - update outdated layout page naming

### DIFF
--- a/apps/docs/src/pages/theming/create-styles.md
+++ b/apps/docs/src/pages/theming/create-styles.md
@@ -8,7 +8,7 @@ docs: 'theming/create-styles.md'
 	import { Heading } from 'components';
     import { Demo, CreateStylesDemos } from "@svelteuidev/demos";
 	import { Space } from '@svelteuidev/core';
-    
+
 	const styles = `<style id='svelteui-inject-body' type='text/css'>.article>*:nth-child(3){margin-top:15rem!important;}@media(max-width: 800px){.article>*:nth-child(3){margin-top:18rem!important;}}<\/style>`;
 </script>
 
@@ -246,7 +246,7 @@ const globalStyles = globalCss({
   body: { margin: 0 },
 });
 
-// then import it in your top level component i.e __layout.svelte or App.svelte
+// then import it in your top level component i.e +layout.svelte or App.svelte
 <script>
     import { globalStyles } from 'styles.js'
 

--- a/apps/docs/src/pages/theming/ssr.md
+++ b/apps/docs/src/pages/theming/ssr.md
@@ -43,7 +43,7 @@ You don't need to install any additional tooling to get access to server side re
 
 ## 1.
 
-In your top level `__layout.svelte` file, wrap your app in the SvelteUIProvider component:
+In your top level `+layout.svelte` file, wrap your app in the SvelteUIProvider component:
 
 ```svelte
 <script>

--- a/apps/docs/src/pages/theming/svelteui-provider.md
+++ b/apps/docs/src/pages/theming/svelteui-provider.md
@@ -36,7 +36,7 @@ For SvelteUI to work properly, you need to set up the SvelteUIProvider at the to
 </SvelteUIProvider>
 ```
 
-**For SvelteKit projects -> `__layout.svelte`**
+**For SvelteKit projects -> `+layout.svelte`**
 
 ```svelte
 <script>


### PR DESCRIPTION
a fix for #226 regarding old styled `__layout.svelte` files being replaced by `+layout.svelte`.
