### PR TITLE
[docs] fix links to docs in header (missing "/apps")

### DIFF
--- a/apps/docs/src/components/Heading.svelte
+++ b/apps/docs/src/components/Heading.svelte
@@ -8,7 +8,7 @@
 
 	const links = {
 		github: 'https://github.com/svelteuidev/svelteui/blob/main/packages/',
-		docs: 'https://github.com/svelteuidev/svelteui/blob/main/app/docs/src/pages/',
+		docs: 'https://github.com/svelteuidev/svelteui/blob/main/apps/docs/src/pages/',
 		npm: 'https://www.npmjs.com/package/'
 	};
 

--- a/apps/docs/src/components/Heading.svelte
+++ b/apps/docs/src/components/Heading.svelte
@@ -8,7 +8,7 @@
 
 	const links = {
 		github: 'https://github.com/svelteuidev/svelteui/blob/main/packages/',
-		docs: 'https://github.com/svelteuidev/svelteui/blob/main/docs/src/pages/',
+		docs: 'https://github.com/svelteuidev/svelteui/blob/main/app/docs/src/pages/',
 		npm: 'https://www.npmjs.com/package/'
 	};
 


### PR DESCRIPTION
Update header to fix link to docs page(s)

Noticed this while working on https://github.com/svelteuidev/svelteui/pull/235
### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [x] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.

### Tests

- [x] Run the tests with `npm test` and lint the project with `yarn lint` or just run `yarn repo:prepush` and check to see if it's passing.
