### PR TITLE
[docs] svelte global CSS for use in overrides

### DIFF
--- a/apps/docs/src/pages/theming/override.md
+++ b/apps/docs/src/pages/theming/override.md
@@ -101,3 +101,38 @@ Various (but not all) components support changing their root elements with the `
 
 <Box root="p">I was a div but now I'm a paragraph tag!</Box>
 ```
+## Overriding using Svelte's `<style global>` functionality
+
+Svelte's global CSS styling feature can be used to override and enhance styles for SvelteUI components and their internal DOM elements.
+
+Given a component with a known structure, like `AppShell`, which contains a `div.app-shell` element used as a container, the following component would work:
+      
+```svelte
+<AppShell height="100%" class="app-shell h-full flex flex-col">
+  <YourHeaderComponent slot="header" {user} />
+
+  <!-- Content -->
+  <slot class="container flex-grow" />
+
+  <!-- Footer -->
+  <YourFooterComponent slot="footer" />
+</AppShell>
+      
+<style global>
+ /* Target the first inner wrapper container inside the AppShell */
+ .app-shell > div {
+   height: 100%;
+   display: flex;
+   flex-direction: column;
+ }
+ 
+ /* Target the wrapper div *for content* which is two layers down inside the AppShell */
+ .app-shell > div > div.body {
+   flex-grow: 1;
+ }
+</style>      
+```
+
+The [TailwindCSS][tailwindcss]-flavored example code above makes targeted changes to the implicit inner `<div>` contained in [`AppShell`](https://github.com/svelteuidev/svelteui/blob/main/packages/svelteui-core/src/components/AppShell/AppShell.svelte) and another inteernal `<div>` in order to create a full page AppShell which expands to the height of the page.
+      
+[tailwindcss]: https://tailwindcss.com


### PR DESCRIPTION
Add documentation showing how global styles can be used for targeted style overrides.

This doesn't really *solve* [#231](https://github.com/svelteuidev/svelteui/issues/231) but it does provide a work-around.

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [x] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.

### Tests

- [x] Run the tests with `npm test` and lint the project with `yarn lint` or just run `yarn repo:prepush` and check to see if it's passing.
