### PR TITLE
[@svelteuidev/composables] Fixes #241:  focus trap action and usage on modal

### DIFF
--- a/apps/docs/src/includes/sidebar.md
+++ b/apps/docs/src/includes/sidebar.md
@@ -121,6 +121,7 @@
   - [use-css-variable](composables/use-css-variable)
   - [use-download](composables/use-download)
   - [use-focus](composables/use-focus)
+  - [use-focus-trap](composables/use-focus-trap)
   - [use-hot-key](composables/use-hot-key)
   - [use-io](composables/use-io)
   - [use-lazy](composables/use-lazy)

--- a/apps/docs/src/pages/composables/use-focus-trap.md
+++ b/apps/docs/src/pages/composables/use-focus-trap.md
@@ -1,0 +1,38 @@
+---
+title: 'use-focus-trap'
+group: 'svelteuidev-composables'
+packageGroup: '@svelteuidev/composables'
+slug: /composables/use-focus-trap/
+description: 'Traps the focus inside the given DOM node'
+import: "import { focustrap } from '@svelteuidev/composables';"
+docs: 'composables/use-focus-trap.md'
+source: 'svelteui-composables/src/actions/use-focus/use-focus-trap.ts'
+---
+
+<script lang='ts'>
+    import { Demo, ComposableDemos } from '@svelteuidev/demos';
+    import { Heading } from 'components';
+</script>
+
+<Heading />
+
+## Usage
+
+The `use-focus-trap` action traps the focus inside a given DOM node. The node must include at least one focusable element, and it will give priority to a node with the `autofocus` property.
+
+```svelte
+<script>
+  import { focustrap } from './use-focus-trap';
+</script>
+
+<div use:focustrap>
+  <h1>Title</h1>
+  <input /> <!-- This will be focused -->
+</div>
+```
+
+## Definition
+
+```ts
+export function focustrap(node: HTMLElement): ReturnType<Action>;
+```

--- a/packages/svelteui-composables/src/actions/index.ts
+++ b/packages/svelteui-composables/src/actions/index.ts
@@ -3,6 +3,7 @@ export * from './use-clipboard/index.js';
 export * from './use-css-variable/index.js';
 export * from './use-download/index.js';
 export * from './use-focus/index.js';
+export * from './use-focus-trap/index.js';
 export * from './use-hot-key/index.js';
 export * from './use-io/index.js';
 export * from './use-lazy/index.js';

--- a/packages/svelteui-composables/src/actions/use-focus-trap/index.ts
+++ b/packages/svelteui-composables/src/actions/use-focus-trap/index.ts
@@ -1,0 +1,1 @@
+export { focustrap } from './use-focus-trap.js';

--- a/packages/svelteui-composables/src/actions/use-focus-trap/use-focus-trap.stories.svelte
+++ b/packages/svelteui-composables/src/actions/use-focus-trap/use-focus-trap.stories.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import { Meta, Template, Story } from '@storybook/addon-svelte-csf';
+	import { Button, Text, Title, NativeSelect, TextInput } from '@svelteuidev/core';
+  import { focustrap } from './use-focus-trap';
+</script>
+
+<Meta title="Composables/use-focus-trap" />
+
+<Template let:args>
+  <div use:focustrap>
+    <Title>Form</Title>
+    <Text>Please fill out this form</Text>
+    <TextInput
+      placeholder="Your name"
+      label="Full name"
+    />
+    <NativeSelect data={['Svelte', 'React', 'Vue', 'Angular', 'Solid']}
+      placeholder="Pick one"
+      label="Select your favorite framework/library"
+      description="This is anonymous"
+    />
+    <Button>Submit</Button>
+  </div>
+</Template>
+
+<Story name="use-focus-trap" />

--- a/packages/svelteui-composables/src/actions/use-focus-trap/use-focus-trap.ts
+++ b/packages/svelteui-composables/src/actions/use-focus-trap/use-focus-trap.ts
@@ -1,0 +1,30 @@
+import type { Action, FocusableElement } from '../../shared/actions/types';
+
+const FOCUSABLE = 'input, textarea, select, a, button, [tabindex]:not([tabindex="-1"])';
+
+/**
+ * With the `use-focus-trap` action, the first focusable child gets the focus in the provided affected dom node
+ *
+ * ```tsx
+ *  <div use:focus-trap>
+ *    <input placeholder="Focused" />
+ *  </div>
+ * ```
+ * @see https://svelteui.org/actions/use-focus-trap
+ */
+export function focustrap(node: HTMLElement): ReturnType<Action> | undefined {
+	let focusElement = node.querySelector('[data-autofocus]') as FocusableElement;
+
+	if (!focusElement) {
+		const focusableElements = node.querySelectorAll(FOCUSABLE);
+		if (focusableElements.length === 0) {
+			if (process.env.NODE_ENV === 'development') {
+				console.warn('[@svelteuidev/composables/use-focus-trap] No focusable children in element');
+			}
+			return;
+		}
+		focusElement = focusableElements[0] as FocusableElement;
+	}
+
+	setTimeout(() => focusElement?.focus({ preventScroll: true }), 0);
+}

--- a/packages/svelteui-composables/src/actions/use-focus/use-focus.ts
+++ b/packages/svelteui-composables/src/actions/use-focus/use-focus.ts
@@ -4,11 +4,11 @@ import type { Action, FocusableElement } from '../../shared/actions/types';
  * With the `use-focus` action, the affected dom node gets focused when it is mounted into the dom. Only “focusable” elements should use this action. Type errors will appear if this is not the case.
  *
  * ```tsx
- *  <button use:clipboard={'This text will be copied'}>Copy Me</button>
+ *  <input use:focus placeholder="Focused"/>
  * ```
  * @see https://svelteui.org/actions/use-focus
  */
-export function focus(node: FocusableElement): ReturnType<Action> {
+export function focus(node: FocusableElement): ReturnType<Action> | undefined {
 	node.focus();
 
 	return;

--- a/packages/svelteui-core/src/components/Modal/Modal.svelte
+++ b/packages/svelteui-core/src/components/Modal/Modal.svelte
@@ -7,7 +7,7 @@
 	import { OptionalPortal } from '../Portal';
 	import { Box } from '../Box';
 	import { randomID, colorScheme, css } from '$lib/styles';
-	import { lockscroll } from '@svelteuidev/composables';
+	import { focustrap, lockscroll } from '@svelteuidev/composables';
 	import { createEventDispatcher, onMount } from 'svelte';
 	import { fade, scale } from 'svelte/transition';
 	import { sineInOut } from 'svelte/easing';
@@ -91,6 +91,7 @@
 			class={cx(className, getStyles({ css: override }))}
 		>
 			<div
+        role="presentation"
 				class={classes.inner}
 				use:lockscroll={lockScroll}
 				on:keydown|capture={(event) => {
@@ -110,6 +111,7 @@
 						aria-describedby={bodyId}
 						aria-modal
 						tabIndex={-1}
+            use={[focustrap]}
 					>
 						{#if title || withCloseButton}
 							<div class={classes.header}>


### PR DESCRIPTION
Fixes #241.

* Action `focus-trap` that searches for a focusable child of a node and applies focus.
  * respective story and docs

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `yarn lint` or just run `yarn repo:prepush` and check to see if it's passing.
