### PR TITLE
[@svelteuidev/core] #217: fix menu open/close events not being dispatched

### DIFF
--- a/packages/svelteui-core/src/components/Menu/Menu.svelte
+++ b/packages/svelteui-core/src/components/Menu/Menu.svelte
@@ -45,6 +45,8 @@
 		transitionOptions: $$Props['transitionOptions'] = { duration: 100 };
 	export { className as class };
 
+  const dispatch = createEventDispatcher();
+
 	/** Function that allows changing the state of the menu from outside the component */
 	export function open() {
 		handleOpen();
@@ -55,8 +57,6 @@
 	export function toggle() {
 		toggleMenu();
 	}
-
-	const dispatch = createEventDispatcher();
 
 	let delayTimeout: number;
 	let referenceElement: HTMLButtonElement;
@@ -69,7 +69,7 @@
 		callback: () => _opened && handleClose()
 	};
 	const uuid: string = useHash(menuId);
-	const forwardEvents = createEventForwarder(get_current_component());
+	const forwardEvents = createEventForwarder(get_current_component(), ['open', 'close']);
 	const castKeyboardEvent = <T = KeyboardEvent>(event): T => event;
 
 	// can be turned into an action


### PR DESCRIPTION
FIxes #217.

Due to the event forwarding logic, it was necessary to set the `open` and `close` events as exceptions. Probably in the future we will have to revisit the event forwarding logic.

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `yarn lint` or just run `yarn repo:prepush` and check to see if it's passing.
