### PR TITLE
[@svelteui/demos] Fixed incorrect value being shown in GridDemo

### DIFF
--- a/packages/svelteui-demos/src/components/Configurator/controls/SizeControl.svelte
+++ b/packages/svelteui-demos/src/components/Configurator/controls/SizeControl.svelte
@@ -12,20 +12,27 @@
 		{ value: 100, label: 'xl' }
 	];
 
+  const values = [
+    "xs",
+    "sm",
+    "md",
+    "lg",
+    "xl"
+  ]
+
 	const dispatch = createEventDispatcher();
 
 	export let value: string;
 	export let label: DemoControlSize['label'];
 
-	$: _value = MARKS.find((mark) => mark.label === value).value;
+	$: _value = MARKS.find((mark) => mark.label === value).label;
 
 	function onChange(e) {
-		const value: number = e.currentTarget.value * 1;
-		dispatch('change', MARKS.find((mark) => mark.value === value).label);
+		dispatch('change', e.currentTarget.value);
 	}
 </script>
 
-<NativeSelect value={_value} {label} data={MARKS} on:change={onChange} />
+<NativeSelect value={_value} {label} data={values} on:change={onChange} />
 
 <!--
   TODO: this is how we probably will use Slider component here when it will be implemented


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

Before submitting a PR, please read https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md

1. Give the PR a descriptive title
2. Ensure there is a related issue and it is referenced in the PR text
3. Ensure there are tests that cover the changes
4. Ensure that `yarn repo:prepush` passes.

Happy contributing!

-->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [x] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.

### Tests

- [x] Run the tests with `npm test` and lint the project with `yarn lint` or just run `yarn repo:prepush` and check to see if it's passing.

Right now, in the Grow section of the Grid component, the Spacing field doesn't update its value when we change the option even through the option is reflected in the demo. This is what it looks like:

https://user-images.githubusercontent.com/94300963/206893939-70dc9ca2-b8ac-4708-9615-62c923cd0a36.mov

Most of the code in the GridDemo was built with the expectation that the Spacing field would be represented in a Slider component which made a few bugs with the current NativeSelect component. So, this commit fixes it