### PR TITLE
[@svelteuidev/core] `createStyles` improvement

### DIFF
--- a/packages/svelteui-composables/src/actions/use-focus-trap/use-focus-trap.stories.svelte
+++ b/packages/svelteui-composables/src/actions/use-focus-trap/use-focus-trap.stories.svelte
@@ -1,26 +1,24 @@
 <script lang="ts">
 	import { Meta, Template, Story } from '@storybook/addon-svelte-csf';
 	import { Button, Text, Title, NativeSelect, TextInput } from '@svelteuidev/core';
-  import { focustrap } from './use-focus-trap';
+	import { focustrap } from './use-focus-trap';
 </script>
 
 <Meta title="Composables/use-focus-trap" />
 
 <Template let:args>
-  <div use:focustrap>
-    <Title>Form</Title>
-    <Text>Please fill out this form</Text>
-    <TextInput
-      placeholder="Your name"
-      label="Full name"
-    />
-    <NativeSelect data={['Svelte', 'React', 'Vue', 'Angular', 'Solid']}
-      placeholder="Pick one"
-      label="Select your favorite framework/library"
-      description="This is anonymous"
-    />
-    <Button>Submit</Button>
-  </div>
+	<div use:focustrap>
+		<Title>Form</Title>
+		<Text>Please fill out this form</Text>
+		<TextInput placeholder="Your name" label="Full name" />
+		<NativeSelect
+			data={['Svelte', 'React', 'Vue', 'Angular', 'Solid']}
+			placeholder="Pick one"
+			label="Select your favorite framework/library"
+			description="This is anonymous"
+		/>
+		<Button>Submit</Button>
+	</div>
 </Template>
 
 <Story name="use-focus-trap" />

--- a/packages/svelteui-core/src/components/Alert/Alert.styles.ts
+++ b/packages/svelteui-core/src/components/Alert/Alert.styles.ts
@@ -31,7 +31,7 @@ export default createStyles((theme, { color, radius, variant }: AlertStylesParam
 			borderRadius: theme.fn.radius(radius),
 			border: '1px solid transparent',
 			'&.light': {
-				[`${theme.dark} &`]: {
+				darkMode: {
 					backgroundColor: theme.fn.variant({ variant: 'light', color }).background[0],
 					color: theme.fn.variant({ variant: 'light', color }).color[0]
 				},
@@ -40,7 +40,7 @@ export default createStyles((theme, { color, radius, variant }: AlertStylesParam
 			},
 
 			'&.filled': {
-				[`${theme.dark} &`]: {
+				darkMode: {
 					backgroundColor: theme.fn.variant({ variant: 'filled', color }).background[0]
 				},
 				backgroundColor: theme.fn.variant({ variant: 'filled', color }).background[1],
@@ -52,7 +52,7 @@ export default createStyles((theme, { color, radius, variant }: AlertStylesParam
 			},
 
 			'&.outline': {
-				[`${theme.dark} &`]: {
+				darkMode: {
 					color: theme.fn.variant({ variant: 'outline', color }).color[0],
 					borderColor: theme.fn.variant({ variant: 'outline', color }).border[0]
 				},

--- a/packages/svelteui-core/src/components/Alert/Alert.svelte
+++ b/packages/svelteui-core/src/components/Alert/Alert.svelte
@@ -29,7 +29,7 @@
 		dispatch('close');
 	}
 
-	$: ({ cx, classes } = useStyles({ color, radius, variant }, { override }));
+	$: ({ cx, classes } = useStyles({ color, radius, variant }, { name: 'Alert', override }));
 </script>
 
 <Box {use} bind:element role="alert" class={cx(className, variant, classes.root)} {...$$restProps}>

--- a/packages/svelteui-core/src/components/AppShell/HorizontalSection/HorizontalSection.styles.ts
+++ b/packages/svelteui-core/src/components/AppShell/HorizontalSection/HorizontalSection.styles.ts
@@ -67,7 +67,7 @@ export default createStyles(
 
 		return {
 			root: {
-				[`${theme.dark} &`]: {
+				darkMode: {
 					backgroundColor: theme.fn.themeColor('dark', 7),
 					[section === 'navbar' ? 'borderRight' : 'borderLeft']: `1px solid ${theme.fn.themeColor(
 						'dark',

--- a/packages/svelteui-core/src/components/AppShell/HorizontalSection/HorizontalSection.svelte
+++ b/packages/svelteui-core/src/components/AppShell/HorizontalSection/HorizontalSection.svelte
@@ -49,7 +49,7 @@
 		zIndex,
 		section,
 		hidden
-	}));
+	}, { name: "HorizontalSection" }));
 
 	const injectRoot = globalCss({
 		':root': {

--- a/packages/svelteui-core/src/components/Checkbox/Checkbox.styles.ts
+++ b/packages/svelteui-core/src/components/Checkbox/Checkbox.styles.ts
@@ -117,7 +117,7 @@ export default createStyles(
 			},
 
 			iconWrapper: {
-        ref: getRef('iconWrapper'),
+				ref: getRef('iconWrapper'),
 				color: '#ffffff',
 				transform: 'translateY(5px) scale(0.5)',
 				opacity: 0,
@@ -143,7 +143,7 @@ export default createStyles(
 			},
 
 			icon: {
-        ref: getRef('icon'),
+				ref: getRef('icon'),
 				color: '#ffffff',
 				width: iconSizes[size],
 				height: iconSizes[size],

--- a/packages/svelteui-core/src/components/Checkbox/Checkbox.styles.ts
+++ b/packages/svelteui-core/src/components/Checkbox/Checkbox.styles.ts
@@ -40,7 +40,7 @@ export const iconSizes = {
 };
 
 export default createStyles(
-	(theme, { color, radius, size, transitionDuration }: CheckboxStyleParams) => {
+	(theme, { color, radius, size, transitionDuration }: CheckboxStyleParams, getRef) => {
 		return {
 			root: {
 				display: 'flex',
@@ -79,7 +79,7 @@ export default createStyles(
 				margin: 0,
 				transition: `border-color ${transitionDuration}ms ease, background-color ${transitionDuration}ms ease`,
 
-				[`${theme.dark} &`]: {
+				darkMode: {
 					backgroundColor: '$dark400',
 					borderColor: '$dark400'
 				},
@@ -89,7 +89,7 @@ export default createStyles(
 					color: '#ffffff',
 					borderRadius: `$${radius}`,
 
-					[`& + .iconWrapper`]: {
+					[`& + .${getRef('iconWrapper')}`]: {
 						opacity: 1,
 						transform: 'translateY(0) scale(1)'
 					}
@@ -100,7 +100,7 @@ export default createStyles(
 					borderColor: '$gray300',
 					cursor: 'not-allowed',
 
-					[`& + .iconWrapper`]: {
+					[`& + .${getRef('iconWrapper')}`]: {
 						color: '$gray500',
 						backgroundColor: '$gray200',
 						borderColor: '$gray300'
@@ -109,7 +109,7 @@ export default createStyles(
 					[`${theme.dark} &`]: {
 						backgroundColor: '$dark400',
 						borderColor: '$dark600',
-						[`& + .icon`]: {
+						[`& + .${getRef('icon')}`]: {
 							color: '$dark600'
 						}
 					}
@@ -117,6 +117,7 @@ export default createStyles(
 			},
 
 			iconWrapper: {
+        ref: getRef('iconWrapper'),
 				color: '#ffffff',
 				transform: 'translateY(5px) scale(0.5)',
 				opacity: 0,
@@ -142,6 +143,7 @@ export default createStyles(
 			},
 
 			icon: {
+        ref: getRef('icon'),
 				color: '#ffffff',
 				width: iconSizes[size],
 				height: iconSizes[size],

--- a/packages/svelteui-core/src/components/Checkbox/Checkbox.svelte
+++ b/packages/svelteui-core/src/components/Checkbox/Checkbox.svelte
@@ -30,7 +30,7 @@
 	const forwardEvents = createEventForwarder(get_current_component());
 
 	$: checked = indeterminate || checked;
-	$: ({ cx, classes, getStyles } = useStyles({ color, radius, size, transitionDuration }));
+	$: ({ cx, classes, getStyles } = useStyles({ color, radius, size, transitionDuration }, { name: "Checkbox" }));
 </script>
 
 <!--

--- a/packages/svelteui-core/src/components/Code/Code.styles.ts
+++ b/packages/svelteui-core/src/components/Code/Code.styles.ts
@@ -23,7 +23,7 @@ export default createStyles((theme, { color, block, noMono, width }: CodeStylePa
 	const { themeColor }: typeof theme.fn = theme.fn;
 	return {
 		root: {
-			[`${theme.dark} &`]: {
+			darkMode: {
 				backgroundColor: color === 'dark' ? themeColor(color, 4) : rgba(themeColor(color, 8), 0.35),
 				color: color === 'dark' ? themeColor('dark', 0) : 'white'
 			},
@@ -38,7 +38,7 @@ export default createStyles((theme, { color, block, noMono, width }: CodeStylePa
 			width: block ? `${width}%` : 'auto'
 		},
 		copy: {
-			[`${theme.dark} &`]: {
+			darkMode: {
 				backgroundColor: 'rgba(52, 58, 64, 0.35);',
 				color: 'white'
 			},

--- a/packages/svelteui-core/src/components/Code/Code.svelte
+++ b/packages/svelteui-core/src/components/Code/Code.svelte
@@ -54,7 +54,7 @@
 	$: if (observable) override = { display: 'none' };
 	// --------------Error Handling-------------------
 
-	$: ({ cx, getStyles } = useStyles({ color, block, noMono, width }));
+	$: ({ cx, classes, getStyles } = useStyles({ color, block, noMono, width }));
 </script>
 
 <Error {observable} component="Code" code={err} />
@@ -76,7 +76,7 @@ Inline or block code without syntax highlighting
 		bind:this={element}
 		use:useActions={use}
 		use:forwardEvents
-		class={cx(className, getStyles({ css: override }))}
+		class={cx(className, classes.root, getStyles({ css: override }))}
 		{...$$restProps}>
 		{#if !noMono}
 			<code class={className}><slot>Write some code</slot></code>
@@ -84,7 +84,7 @@ Inline or block code without syntax highlighting
 			<p class={className}><slot>Write some code</slot></p>
 		{/if}
       {#if copy}
-			<button on:click={toggle} use:clipboard={message} class:copy><CopyIcon {copied} /></button>
+			<button on:click={toggle} use:clipboard={message} class={classes.copy}><CopyIcon {copied} /></button>
 		{/if}
     </pre>
 {:else}
@@ -92,7 +92,7 @@ Inline or block code without syntax highlighting
 		bind:this={element}
 		use:useActions={use}
 		use:forwardEvents
-		class={cx(className, getStyles({ css: override }))}
+		class={cx(className, classes.root, getStyles({ css: override }))}
 		{...$$restProps}
 	>
 		<slot>Write some code</slot>

--- a/packages/svelteui-core/src/components/Grid/Col/Col.styles.ts
+++ b/packages/svelteui-core/src/components/Grid/Col/Col.styles.ts
@@ -53,7 +53,7 @@ const breakpointsStyles = (
 				flexShrink: 0,
 				maxWidth: grow ? 'unset' : columnWidth(sizes[size], columns),
 				marginLeft: columnOffset(offsets[size], columns),
-        padding: theme.fn.size({ size: size, sizes: theme.space }) / 2,
+				padding: theme.fn.size({ size: size, sizes: theme.space }) / 2
 			};
 		}
 		return acc;

--- a/packages/svelteui-core/src/components/Input/Input.styles.ts
+++ b/packages/svelteui-core/src/components/Input/Input.styles.ts
@@ -205,8 +205,8 @@ export default createStyles(
 			withIcon: {
 				paddingLeft: typeof iconWidth === 'number' ? iconWidth : sizes[size] ?? sizes.md
 			},
-			invalid: {
-				[`${theme.dark} &`]: {
+			'& .invalid': {
+				darkMode: {
 					color: '$red600 !important',
 					borderColor: '$red600 !important',
 					'&::placeholder': {
@@ -222,7 +222,7 @@ export default createStyles(
 				}
 			},
 			disabled: {
-				[`${theme.dark} &`]: {
+				darkMode: {
 					backgroundColor: '$dark600 !important'
 				},
 				backgroundColor: '$gray100 !important',
@@ -235,7 +235,7 @@ export default createStyles(
 				}
 			},
 			icon: {
-				[`${theme.dark} &`]: {
+				darkMode: {
 					color: invalid ? 'red600' : '$dark200'
 				},
 				pointerEvents: 'none',

--- a/packages/svelteui-core/src/components/Loader/Loader.styles.ts
+++ b/packages/svelteui-core/src/components/Loader/Loader.styles.ts
@@ -22,9 +22,9 @@ export interface LoaderPropsExtended extends Partial<SVGElement> {
 }
 
 export interface LoaderProps extends DefaultProps<Omit<Component, 'prototype'>> {
-	variant: LoaderPropsExtended['variant'];
-	color: LoaderPropsExtended['color'];
-	size: LoaderPropsExtended['size'];
+	variant?: LoaderPropsExtended['variant'];
+	color?: LoaderPropsExtended['color'];
+	size?: LoaderPropsExtended['size'];
 }
 
 export const getCorrectShade = (color: SvelteUIColor | string, dark: boolean = false) => {

--- a/packages/svelteui-core/src/components/Menu/Menu.svelte
+++ b/packages/svelteui-core/src/components/Menu/Menu.svelte
@@ -45,7 +45,7 @@
 		transitionOptions: $$Props['transitionOptions'] = { duration: 100 };
 	export { className as class };
 
-  const dispatch = createEventDispatcher();
+	const dispatch = createEventDispatcher();
 
 	/** Function that allows changing the state of the menu from outside the component */
 	export function open() {

--- a/packages/svelteui-core/src/components/Menu/MenuItem/MenuItem.styles.ts
+++ b/packages/svelteui-core/src/components/Menu/MenuItem/MenuItem.styles.ts
@@ -33,41 +33,39 @@ export function getContextItemIndex(
 	}
 
 	return Array.from(
-		findAncestor(node, options.parentClassName).querySelectorAll(options.elementSelector)
+		findAncestor(node, options.parentClassName)?.querySelectorAll(options.elementSelector) ?? []
 	).findIndex((element) => element === node);
 }
 
 export default createStyles((theme, { color, radius }: MenuItemStylesParams) => {
 	return {
 		root: {
-			'&.svelteui-Menu-item': {
-				[`${theme.dark} &`]: {
-					color: color ? theme.fn.themeColor(color, 5) : theme.fn.themeColor('dark', 0),
-					'&:disabled': {
-						color: theme.fn.themeColor('dark', 3)
-					}
-				},
-				WebkitTapHighlightColor: 'transparent',
-				fontSize: theme.fontSizes.sm,
-				border: 0,
-				backgroundColor: 'transparent',
-				outline: 0,
-				width: '100%',
-				textAlign: 'left',
-				display: 'inline-block',
-				textDecoration: 'none',
-				boxSizing: 'border-box',
-				padding: `${+theme.space.xs.value}px ${+theme.space.sm.value}px`,
-				cursor: 'pointer',
-				borderRadius: theme.fn.radius(radius),
-				color: color ? theme.fn.themeColor(color, 7) : 'black',
-
+			darkMode: {
+				color: color ? theme.fn.themeColor(color, 5) : theme.fn.themeColor('dark', 0),
 				'&:disabled': {
-					color: theme.fn.themeColor('gray', 5),
-					pointerEvents: 'none'
+					color: theme.fn.themeColor('dark', 3)
 				}
 			},
-			'&.itemHovered': {
+			WebkitTapHighlightColor: 'transparent',
+			fontSize: theme.fontSizes.sm,
+			border: 0,
+			backgroundColor: 'transparent',
+			outline: 0,
+			width: '100%',
+			textAlign: 'left',
+			display: 'inline-block',
+			textDecoration: 'none',
+			boxSizing: 'border-box',
+			padding: `${+theme.space.xs.value}px ${+theme.space.sm.value}px`,
+			cursor: 'pointer',
+			borderRadius: theme.fn.radius(radius),
+			color: color ? theme.fn.themeColor(color, 7) : 'black',
+
+			'&:disabled': {
+				color: theme.fn.themeColor('gray', 5),
+				pointerEvents: 'none'
+			},
+			'&:hover': {
 				[`${theme.dark} &`]: {
 					backgroundColor: color
 						? theme.fn.rgba(theme.fn.themeColor(color, 8), 0.35)

--- a/packages/svelteui-core/src/components/Menu/MenuItem/MenuItem.svelte
+++ b/packages/svelteui-core/src/components/Menu/MenuItem/MenuItem.svelte
@@ -28,10 +28,10 @@
 	const castKeyboardEvent = <T = KeyboardEvent>(event): T => event;
 
 	$: itemIndex = getContextItemIndex(
-		{ elementSelector: '.svelteui-Menu-item', parentClassName: 'svelteui-Menu-body' },
+		{ elementSelector: '.svelteui-MenuItem-root', parentClassName: 'svelteui-Menu-body' },
 		element
 	);
-	$: ({ cx, classes } = useStyles({ color, radius }, { override }));
+	$: ({ cx, classes } = useStyles({ color, radius }, { override, name: 'MenuItem' }));
 	$: ({ hovered, radius, onItemClick, onItemHover, onItemKeyDown } = $state);
 </script>
 
@@ -41,7 +41,7 @@
 	bind:element
 	type="button"
 	role="menuitem"
-	class={cx(className, classes.root, 'svelteui-Menu-item', {
+	class={cx(className, classes.root, {
 		itemHovered: hovered === itemIndex
 	})}
 	{disabled}

--- a/packages/svelteui-core/src/components/Modal/Modal.svelte
+++ b/packages/svelteui-core/src/components/Modal/Modal.svelte
@@ -91,7 +91,7 @@
 			class={cx(className, getStyles({ css: override }))}
 		>
 			<div
-        role="presentation"
+				role="presentation"
 				class={classes.inner}
 				use:lockscroll={lockScroll}
 				on:keydown|capture={(event) => {
@@ -111,7 +111,7 @@
 						aria-describedby={bodyId}
 						aria-modal
 						tabIndex={-1}
-            use={[focustrap]}
+						use={[focustrap]}
 					>
 						{#if title || withCloseButton}
 							<div class={classes.header}>

--- a/packages/svelteui-core/src/components/Notification/Notification.styles.ts
+++ b/packages/svelteui-core/src/components/Notification/Notification.styles.ts
@@ -74,7 +74,7 @@ export default createStyles((theme, { color, radius }: NotificationStylesParams,
 			}
 		},
 		icon: {
-      ref: getRef('icon'),
+			ref: getRef('icon'),
 			boxSizing: 'border-box',
 			marginRight: theme.space.mdPX.value,
 			width: 28,

--- a/packages/svelteui-core/src/components/Notification/Notification.styles.ts
+++ b/packages/svelteui-core/src/components/Notification/Notification.styles.ts
@@ -21,7 +21,7 @@ export interface NotificationStylesParams {
 	radius: SvelteUINumberSize;
 }
 
-export default createStyles((theme, { color, radius }: NotificationStylesParams) => {
+export default createStyles((theme, { color, radius }: NotificationStylesParams, getRef) => {
 	const _radiusPx = theme.fn.radius(radius);
 	const _radius = parseInt(_radiusPx.toString().split('px')[0]);
 	const topBottom = Math.min(Math.max(_radius / 1.2, 4), 30);
@@ -67,13 +67,14 @@ export default createStyles((theme, { color, radius }: NotificationStylesParams)
 				'&::before': {
 					display: 'none'
 				},
-				'& .icon': {
+				[`& .${getRef('icon')}`]: {
 					backgroundColor: colors.backgroundColor,
 					color: theme.colors.white.value
 				}
 			}
 		},
 		icon: {
+      ref: getRef('icon'),
 			boxSizing: 'border-box',
 			marginRight: theme.space.mdPX.value,
 			width: 28,

--- a/packages/svelteui-core/src/components/Notification/Notification.svelte
+++ b/packages/svelteui-core/src/components/Notification/Notification.svelte
@@ -32,7 +32,7 @@
 		dispatch('close');
 	}
 
-	$: ({ cx, classes } = useStyles({ color, radius }, { override }));
+	$: ({ cx, classes } = useStyles({ color, radius }, { override, name: "Notification" }));
 </script>
 
 <Box

--- a/packages/svelteui-core/src/components/NumberInput/NumberInput.styles.ts
+++ b/packages/svelteui-core/src/components/NumberInput/NumberInput.styles.ts
@@ -69,7 +69,7 @@ export default createStyles((theme, { size, radius }: NumberInputStyleParams) =>
 			backgroundColor: 'transparent',
 			marginRight: 1,
 
-			[`${theme.dark} &`]: {
+			darkMode: {
 				borderBottom: '1px solid $dark400',
 				borderLeft: '1px solid $dark400'
 			},
@@ -77,7 +77,7 @@ export default createStyles((theme, { size, radius }: NumberInputStyleParams) =>
 			'&:not(:disabled):hover': {
 				backgroundColor: '$gray50',
 
-				[`${theme.dark} &`]: {
+				darkMode: {
 					backgroundColor: '$dark600'
 				}
 			},
@@ -92,45 +92,45 @@ export default createStyles((theme, { size, radius }: NumberInputStyleParams) =>
 				height: 0,
 				borderStyle: 'solid'
 			},
-			'&.control-up': {
-				borderTopRightRadius: `$${radius}`,
+		},
+    controlUp: {
+      borderTopRightRadius: `$${radius}`,
 
-				'&::after': {
-					borderWidth: '0px 5px 5px 5px',
-					borderColor: 'transparent transparent $black transparent',
+      '&::after': {
+        borderWidth: '0px 5px 5px 5px',
+        borderColor: 'transparent transparent $black transparent',
 
-					[`${theme.dark} &`]: {
-						borderColor: 'transparent transparent $dark50 transparent'
-					}
-				},
+        darkMode: {
+          borderColor: 'transparent transparent $dark50 transparent'
+        }
+      },
 
-				'&:disabled::after': {
-					borderBottomColor: '$gray500',
-					[`${theme.dark} &`]: {
-						borderBottomColor: '$dark200'
-					}
-				}
-			},
-			'&.control-down': {
-				borderTopRightRadius: `$${radius}`,
-				borderBottom: 0,
+      '&:disabled::after': {
+        borderBottomColor: '$gray500',
+        darkMode: {
+          borderBottomColor: '$dark200'
+        }
+      }
+    },
+    controlDown: {
+      borderTopRightRadius: `$${radius}`,
+      borderBottom: 0,
 
-				'&::after': {
-					borderWidth: '5px 5px 0px 5px',
-					borderColor: '$black transparent transparent transparent',
+      '&::after': {
+        borderWidth: '5px 5px 0px 5px',
+        borderColor: '$black transparent transparent transparent',
 
-					[`${theme.dark} &`]: {
-						borderColor: '$dark50 transparent transparent transparent'
-					}
-				},
+        darkMode: {
+          borderColor: '$dark50 transparent transparent transparent'
+        }
+      },
 
-				'&:disabled::after': {
-					borderTopColor: '$gray500',
-					[`${theme.dark} &`]: {
-						borderTopColor: '$dark200'
-					}
-				}
-			}
-		}
+      '&:disabled::after': {
+        borderTopColor: '$gray500',
+        darkMode: {
+          borderTopColor: '$dark200'
+        }
+      }
+    }
 	};
 });

--- a/packages/svelteui-core/src/components/NumberInput/NumberInput.styles.ts
+++ b/packages/svelteui-core/src/components/NumberInput/NumberInput.styles.ts
@@ -91,46 +91,46 @@ export default createStyles((theme, { size, radius }: NumberInputStyleParams) =>
 				width: 0,
 				height: 0,
 				borderStyle: 'solid'
-			},
+			}
 		},
-    controlUp: {
-      borderTopRightRadius: `$${radius}`,
+		controlUp: {
+			borderTopRightRadius: `$${radius}`,
 
-      '&::after': {
-        borderWidth: '0px 5px 5px 5px',
-        borderColor: 'transparent transparent $black transparent',
+			'&::after': {
+				borderWidth: '0px 5px 5px 5px',
+				borderColor: 'transparent transparent $black transparent',
 
-        darkMode: {
-          borderColor: 'transparent transparent $dark50 transparent'
-        }
-      },
+				darkMode: {
+					borderColor: 'transparent transparent $dark50 transparent'
+				}
+			},
 
-      '&:disabled::after': {
-        borderBottomColor: '$gray500',
-        darkMode: {
-          borderBottomColor: '$dark200'
-        }
-      }
-    },
-    controlDown: {
-      borderTopRightRadius: `$${radius}`,
-      borderBottom: 0,
+			'&:disabled::after': {
+				borderBottomColor: '$gray500',
+				darkMode: {
+					borderBottomColor: '$dark200'
+				}
+			}
+		},
+		controlDown: {
+			borderTopRightRadius: `$${radius}`,
+			borderBottom: 0,
 
-      '&::after': {
-        borderWidth: '5px 5px 0px 5px',
-        borderColor: '$black transparent transparent transparent',
+			'&::after': {
+				borderWidth: '5px 5px 0px 5px',
+				borderColor: '$black transparent transparent transparent',
 
-        darkMode: {
-          borderColor: '$dark50 transparent transparent transparent'
-        }
-      },
+				darkMode: {
+					borderColor: '$dark50 transparent transparent transparent'
+				}
+			},
 
-      '&:disabled::after': {
-        borderTopColor: '$gray500',
-        darkMode: {
-          borderTopColor: '$dark200'
-        }
-      }
-    }
+			'&:disabled::after': {
+				borderTopColor: '$gray500',
+				darkMode: {
+					borderTopColor: '$dark200'
+				}
+			}
+		}
 	};
 });

--- a/packages/svelteui-core/src/components/NumberInput/NumberInput.svelte
+++ b/packages/svelteui-core/src/components/NumberInput/NumberInput.svelte
@@ -216,7 +216,7 @@ values and add custom parsers and formatters.
 	>
 		{#if showControls}
 			<button
-				class="control control-up"
+				class={cx(classes.control, classes.controlUp)}
 				type="button"
 				tabIndex={-1}
 				aria-hidden
@@ -226,7 +226,7 @@ values and add custom parsers and formatters.
 				on:mouseleave={onStepDone}
 			/>
 			<button
-				class=" control control-down"
+				class={cx(classes.control, classes.controlDown)}
 				type="button"
 				tabIndex={-1}
 				aria-hidden

--- a/packages/svelteui-core/src/components/Tabs/Tab/Tab.styles.ts
+++ b/packages/svelteui-core/src/components/Tabs/Tab/Tab.styles.ts
@@ -11,8 +11,8 @@ export interface TabProps extends DefaultProps {
 	variant?: TabsVariant;
 	orientation?: 'horizontal' | 'vertical';
 	tabKey?: string;
-  disabled?: boolean;
-  title?: string;
+	disabled?: boolean;
+	title?: string;
 }
 
 export interface TabStyleParams {
@@ -81,9 +81,9 @@ export const getVariantStyles = (
 					color: theme.colors.white.value,
 					background: theme.fn.variant({ variant: 'filled', color })
 				},
-        '&:hover': {
-          background: theme.fn.variant({ variant: 'filled', color }).background[1]
-        }
+				'&:hover': {
+					background: theme.fn.variant({ variant: 'filled', color }).background[1]
+				}
 			}
 		}
 	};
@@ -105,12 +105,12 @@ export default createStyles((theme, { color, orientation }: TabStyleParams) => {
 			darkMode: {
 				color: theme.colors.white.value
 			},
-      ...getVariantStyles(color, orientation, theme),
+			...getVariantStyles(color, orientation, theme),
 			'&:disabled': {
-        cursor: 'not-allowed',
+				cursor: 'not-allowed',
 				color: theme.fn.themeColor('gray', 5),
 				darkMode: {
-          color: theme.fn.themeColor('dark', 3)
+					color: theme.fn.themeColor('dark', 3)
 				}
 			}
 		},
@@ -133,9 +133,9 @@ export default createStyles((theme, { color, orientation }: TabStyleParams) => {
 		label: {},
 		tabContent: {
 			display: 'none',
-      '&.active': {
-        display: 'block'
-      }
+			'&.active': {
+				display: 'block'
+			}
 		}
 	};
 });

--- a/packages/svelteui-core/src/components/Tabs/Tab/Tab.styles.ts
+++ b/packages/svelteui-core/src/components/Tabs/Tab/Tab.styles.ts
@@ -11,6 +11,8 @@ export interface TabProps extends DefaultProps {
 	variant?: TabsVariant;
 	orientation?: 'horizontal' | 'vertical';
 	tabKey?: string;
+  disabled?: boolean;
+  title?: string;
 }
 
 export interface TabStyleParams {
@@ -73,12 +75,15 @@ export const getVariantStyles = (
 				}
 			},
 			'&.active': {
-				color: theme.colors.black.value,
-				background: theme.fn.themeColor('gray', 0),
+				color: theme.colors.white.value,
+				background: theme.fn.variant({ variant: 'filled', color }).background[1],
 				darkMode: {
 					color: theme.colors.white.value,
-					background: theme.fn.themeColor('dark', 6)
-				}
+					background: theme.fn.variant({ variant: 'filled', color })
+				},
+        '&:hover': {
+          background: theme.fn.variant({ variant: 'filled', color }).background[1]
+        }
 			}
 		}
 	};
@@ -100,12 +105,12 @@ export default createStyles((theme, { color, orientation }: TabStyleParams) => {
 			darkMode: {
 				color: theme.colors.white.value
 			},
-			...getVariantStyles(color, orientation, theme),
+      ...getVariantStyles(color, orientation, theme),
 			'&:disabled': {
-				cursor: 'not-allowed',
+        cursor: 'not-allowed',
 				color: theme.fn.themeColor('gray', 5),
 				darkMode: {
-					color: theme.fn.themeColor('dark', 3)
+          color: theme.fn.themeColor('dark', 3)
 				}
 			}
 		},
@@ -119,7 +124,7 @@ export default createStyles((theme, { color, orientation }: TabStyleParams) => {
 		},
 		icon: {
 			'&:not(:only-child)': {
-				marginRight: theme.space.xsPX
+				marginRight: `${theme.space.xs.value}px`
 			},
 			'& *': {
 				display: 'block'
@@ -127,7 +132,10 @@ export default createStyles((theme, { color, orientation }: TabStyleParams) => {
 		},
 		label: {},
 		tabContent: {
-			display: 'none'
+			display: 'none',
+      '&.active': {
+        display: 'block'
+      }
 		}
 	};
 });

--- a/packages/svelteui-core/src/components/Tabs/Tab/Tab.svelte
+++ b/packages/svelteui-core/src/components/Tabs/Tab/Tab.svelte
@@ -19,7 +19,9 @@
 		color: $$Props['color'] = undefined,
 		variant: $$Props['variant'] = undefined,
 		orientation: $$Props['orientation'] = undefined,
-		tabKey: $$Props['tabKey'] = undefined;
+		tabKey: $$Props['tabKey'] = undefined,
+    disabled: $$Props['disabled'] = false,
+		title: $$Props['title'] = undefined;
 	export { className as class };
 
 	// retrieves the reactive context so that Tab has access
@@ -43,20 +45,22 @@
 	// check if item is still checked when the context store updates
 	$: $state, calculateActive();
 
-	$: ({ cx, classes } = useStyles({ color: _color, orientation: _orientation }, { override }));
+	$: ({ cx, classes } = useStyles({ color: _color, orientation: _orientation }, { override, name: "Tab" }));
 </script>
 
 <Box
 	bind:element
 	{use}
-	class={cx('svelteui-tab', className, classes.root, classes[_variant], {
+	class={cx('svelteui-Tab', className, classes.root, {
 		active: _active,
-		[_variant]: true
+    [_variant]: true
 	})}
 	root="button"
 	role="tab"
 	aria-selected={_active}
 	data-key={tabKey}
+  disabled={disabled}
+  title={title}
 	{...$$restProps}
 >
 	<div class={classes.inner}>
@@ -66,7 +70,7 @@
 		{#if label}
 			<div class={classes.label}>{label}</div>
 		{/if}
-		<div class={cx('svelteui-tab-content', classes.tabContent)}>
+		<div class={cx('svelteui-Tab-content', classes.tabContent, { active: _active })}>
 			<slot />
 		</div>
 	</div>

--- a/packages/svelteui-core/src/components/Tabs/Tabs.styles.ts
+++ b/packages/svelteui-core/src/components/Tabs/Tabs.styles.ts
@@ -36,7 +36,7 @@ export interface TabsStyleParams {
 export const getVariantStyles = (
 	orientation: 'horizontal' | 'vertical',
 	theme: SvelteUITheme,
-  getRef
+	getRef
 ): VariantThemeFunction => {
 	return {
 		default: {
@@ -80,14 +80,14 @@ export default createStyles((theme, { orientation, tabPadding }: TabsStyleParams
 		},
 		wrapper: {},
 		tabs: {
-      ref: getRef('tabs')
-    },
+			ref: getRef('tabs')
+		},
 		content: {
 			[orientation === 'horizontal' ? 'paddingTop' : 'paddingLeft']: theme.fn.size({
 				size: tabPadding,
 				sizes: theme.space
 			}),
-      display: 'block'
+			display: 'block'
 		},
 		...getVariantStyles(orientation, theme, getRef)
 	};

--- a/packages/svelteui-core/src/components/Tabs/Tabs.styles.ts
+++ b/packages/svelteui-core/src/components/Tabs/Tabs.styles.ts
@@ -35,7 +35,8 @@ export interface TabsStyleParams {
 
 export const getVariantStyles = (
 	orientation: 'horizontal' | 'vertical',
-	theme: SvelteUITheme
+	theme: SvelteUITheme,
+  getRef
 ): VariantThemeFunction => {
 	return {
 		default: {
@@ -48,7 +49,7 @@ export const getVariantStyles = (
 					: 'borderRight']: `2px solid ${theme.fn.themeColor('dark', 4)}`
 			},
 
-			[`& .tabs`]: {
+			[`& .${getRef('tabs')}`]: {
 				[orientation === 'horizontal' ? 'marginBottom' : 'marginRight']: -2
 			}
 		},
@@ -62,7 +63,7 @@ export const getVariantStyles = (
 					: 'borderRight']: `1px solid ${theme.fn.themeColor('dark', 4)}`
 			},
 
-			[`& .tabs`]: {
+			[`& .${getRef('tabs')}`]: {
 				[orientation === 'horizontal' ? 'marginBottom' : 'marginRight']: -1
 			}
 		},
@@ -72,19 +73,22 @@ export const getVariantStyles = (
 	};
 };
 
-export default createStyles((theme, { orientation, tabPadding }: TabsStyleParams) => {
+export default createStyles((theme, { orientation, tabPadding }: TabsStyleParams, getRef) => {
 	return {
 		root: {
 			display: orientation === 'vertical' ? 'flex' : 'block'
 		},
 		wrapper: {},
-		tabs: {},
+		tabs: {
+      ref: getRef('tabs')
+    },
 		content: {
 			[orientation === 'horizontal' ? 'paddingTop' : 'paddingLeft']: theme.fn.size({
 				size: tabPadding,
 				sizes: theme.space
-			})
+			}),
+      display: 'block'
 		},
-		...getVariantStyles(orientation, theme)
+		...getVariantStyles(orientation, theme, getRef)
 	};
 });

--- a/packages/svelteui-core/src/components/Tabs/Tabs.svelte
+++ b/packages/svelteui-core/src/components/Tabs/Tabs.svelte
@@ -30,8 +30,10 @@
 	const dispatch = createEventDispatcher();
 
 	onMount(() => {
-		const children = element.querySelectorAll('.svelteui-tab-content');
+		const children = element.querySelectorAll('.svelteui-Tab-content');
 		tabNodes = Array.from(children);
+    setupTabs();
+		calculateActive();
 	});
 
 	// initialize a 'reactive context' which is basically
@@ -57,7 +59,7 @@
 	 * to tab changes.
 	 */
 	function setupTabs() {
-		const tabs = element.querySelectorAll('.svelteui-tab');
+		const tabs = element.querySelectorAll('.svelteui-Tab');
 		for (let [index, tab] of Array.from(tabs).entries()) {
 			const key = tab.getAttribute('data-key');
 			tab.addEventListener('click', () => onTabClick(index, key));
@@ -85,11 +87,6 @@
 		}
 	}
 
-	onMount(() => {
-		setupTabs();
-		calculateActive();
-	});
-
 	function onTabClick(index: number, key: string) {
 		dispatch('change', { index: index, key: key });
 		_active = index;
@@ -97,7 +94,7 @@
 	}
 
 	function onTabKeyDown(event: KeyboardEvent) {
-		const tabs = element.querySelectorAll('.svelteui-tab-content');
+		const tabs = element.querySelectorAll('.svelteui-Tab');
 
 		let _index = _active;
 		if (event.code === nextTabCode) {
@@ -123,7 +120,7 @@
 	$: previousTabCode = orientation === 'horizontal' ? 'ArrowLeft' : 'ArrowUp';
 	$: $contextStore, _active, calculateActive();
 
-	$: ({ cx, classes } = useStyles({ orientation, tabPadding }, { override }));
+	$: ({ cx, classes } = useStyles({ orientation, tabPadding }, { override, name: "Tabs" }));
 </script>
 
 <!--

--- a/packages/svelteui-core/src/components/Timeline/Timeline.svelte
+++ b/packages/svelteui-core/src/components/Timeline/Timeline.svelte
@@ -47,7 +47,7 @@
 		lineWidth: lineWidth
 	};
 
-	$: ({ cx, classes } = useStyles({ align, bulletSize, lineWidth }, { override }));
+	$: ({ cx, classes } = useStyles({ align, bulletSize, lineWidth }, { override, name: "Timeline" }));
 </script>
 
 <!--

--- a/packages/svelteui-core/src/components/Timeline/TimelineItem/TimelineItem.styles.ts
+++ b/packages/svelteui-core/src/components/Timeline/TimelineItem/TimelineItem.styles.ts
@@ -30,7 +30,7 @@ export default createStyles(
 	(
 		theme,
 		{ align, bulletSize, radius, color, lineVariant, lineWidth }: TimelineItemStyleParams,
-    getRef
+		getRef
 	) => {
 		const colors = vFunc(color).filled;
 
@@ -68,11 +68,11 @@ export default createStyles(
 						borderLeft: `${lineWidth}px ${lineVariant} ${theme.fn.themeColor('dark', 4)}`
 					}
 				},
-        '&.lineActive': {
-          '&::before': {
-            borderLeftColor: colors.backgroundColor
-          }
-        },
+				'&.lineActive': {
+					'&::before': {
+						borderLeftColor: colors.backgroundColor
+					}
+				},
 				[`&.active .${getRef('bulletContainer')}`]: {
 					borderColor: colors.backgroundColor,
 					backgroundColor: theme.colors.white.value
@@ -80,10 +80,10 @@ export default createStyles(
 				[`&.active .${getRef('bulletContainerWithChild')}`]: {
 					backgroundColor: colors.backgroundColor,
 					color: theme.colors.white.value
-				},
+				}
 			},
 			bulletContainer: {
-        ref: getRef('bulletContainer'),
+				ref: getRef('bulletContainer'),
 				boxSizing: 'border-box',
 				width: bulletSize,
 				height: bulletSize,
@@ -104,7 +104,7 @@ export default createStyles(
 				}
 			},
 			bulletContainerWithChild: {
-        ref: getRef('bulletContainerWithChild'),
+				ref: getRef('bulletContainerWithChild'),
 				borderWidth: 1,
 				backgroundColor: theme.fn.themeColor('gray', 3),
 				color: theme.colors.black.value,

--- a/packages/svelteui-core/src/components/Timeline/TimelineItem/TimelineItem.styles.ts
+++ b/packages/svelteui-core/src/components/Timeline/TimelineItem/TimelineItem.styles.ts
@@ -29,7 +29,8 @@ export interface TimelineItemStyleParams {
 export default createStyles(
 	(
 		theme,
-		{ align, bulletSize, radius, color, lineVariant, lineWidth }: TimelineItemStyleParams
+		{ align, bulletSize, radius, color, lineVariant, lineWidth }: TimelineItemStyleParams,
+    getRef
 	) => {
 		const colors = vFunc(color).filled;
 
@@ -38,8 +39,8 @@ export default createStyles(
 				position: 'relative',
 				boxSizing: 'border-box',
 				color: theme.colors.black.value,
-				paddingLeft: align === 'left' ? theme.space.xlPX : 0,
-				paddingRight: align === 'right' ? theme.space.xlPX : 0,
+				paddingLeft: align === 'left' ? theme.space.xlPX.value : 0,
+				paddingRight: align === 'right' ? theme.space.xlPX.value : 0,
 				textAlign: align,
 				darkMode: {
 					color: theme.fn.themeColor('dark', 0)
@@ -50,14 +51,14 @@ export default createStyles(
 				},
 
 				'&:not(:first-of-type)': {
-					marginTop: theme.space.xlPX
+					marginTop: theme.space.xlPX.value
 				},
 
 				'&::before': {
 					boxSizing: 'border-box',
 					position: 'absolute',
 					top: 0,
-					bottom: -theme.space.xl.value,
+					bottom: `${-theme.space.xl.value}px`,
 					left: align === 'left' ? -lineWidth : 'auto',
 					right: align === 'right' ? -lineWidth : 'auto',
 					borderLeft: `${lineWidth}px ${lineVariant} ${theme.fn.themeColor('gray', 3)}`,
@@ -67,21 +68,22 @@ export default createStyles(
 						borderLeft: `${lineWidth}px ${lineVariant} ${theme.fn.themeColor('dark', 4)}`
 					}
 				},
-				'&.active .bulletContainer': {
+        '&.lineActive': {
+          '&::before': {
+            borderLeftColor: colors.backgroundColor
+          }
+        },
+				[`&.active .${getRef('bulletContainer')}`]: {
 					borderColor: colors.backgroundColor,
 					backgroundColor: theme.colors.white.value
 				},
-				'&.active .bulletContainerWithChild': {
+				[`&.active .${getRef('bulletContainerWithChild')}`]: {
 					backgroundColor: colors.backgroundColor,
 					color: theme.colors.white.value
 				},
-				'&.lineActive': {
-					'&::before': {
-						borderLeftColor: colors.backgroundColor
-					}
-				}
 			},
 			bulletContainer: {
+        ref: getRef('bulletContainer'),
 				boxSizing: 'border-box',
 				width: bulletSize,
 				height: bulletSize,
@@ -102,6 +104,7 @@ export default createStyles(
 				}
 			},
 			bulletContainerWithChild: {
+        ref: getRef('bulletContainerWithChild'),
 				borderWidth: 1,
 				backgroundColor: theme.fn.themeColor('gray', 3),
 				color: theme.colors.black.value,
@@ -115,7 +118,7 @@ export default createStyles(
 			title: {
 				fontWeight: 500,
 				lineHeight: 1,
-				marginBottom: +theme.space.xs.value / 2,
+				marginBottom: `${+theme.space.xs.value / 2}px`,
 				textAlign: align
 			},
 			content: {

--- a/packages/svelteui-core/src/components/Timeline/TimelineItem/TimelineItem.svelte
+++ b/packages/svelteui-core/src/components/Timeline/TimelineItem/TimelineItem.svelte
@@ -67,23 +67,23 @@
 			lineVariant,
 			lineWidth: _lineWidth
 		},
-		{ override }
+		{ override, name: "TimelineItem" }
 	));
 </script>
 
 <Box
 	bind:element
 	{use}
-	class={cx(className, classes.root, {
-		active: _active,
-		lineActive: _lineActive
+	class={cx(className, classes.root,  {
+    lineActive: _lineActive,
+		active: _active
 	})}
 	{...$$restProps}
 >
-	<div class={cx(classes.bulletContainer, { bulletContainerWithChild: bullet })}>
+	<div class={cx(classes.bulletContainer, bullet && classes.bulletContainerWithChild)}>
 		<slot name="bullet">
 			{#if bullet}
-				<svelte:component this={bullet} size={bulletSize} {color} class={classes.bullet} />
+				<svelte:component this={bullet} class={classes.bullet} size={bulletSize} {color} />
 			{/if}
 		</slot>
 	</div>

--- a/packages/svelteui-core/src/components/Tooltip/Tooltip.styles.ts
+++ b/packages/svelteui-core/src/components/Tooltip/Tooltip.styles.ts
@@ -30,8 +30,8 @@ export default createStyles((theme, { color, radius }: TooltipStyleParams) => {
 		},
 
 		body: {
-			[`${theme.dark} &`]: {
-				bc: theme.fn.themeColor(color, 3),
+			darkMode: {
+				backgroundColor: theme.fn.themeColor(color, 3),
 				color: theme.fn.themeColor('dark', 9)
 			},
 			backgroundColor: theme.fn.themeColor(color, 9),
@@ -46,8 +46,8 @@ export default createStyles((theme, { color, radius }: TooltipStyleParams) => {
 		},
 
 		arrow: {
-			[`${theme.dark} &`]: {
-				bg: theme.fn.themeColor(color, 3)
+			darkMode: {
+				backgroundColor: theme.fn.themeColor(color, 3)
 			},
 			background: theme.fn.themeColor(color, 9),
 			zIndex: 0

--- a/packages/svelteui-core/src/components/Tooltip/Tooltip.svelte
+++ b/packages/svelteui-core/src/components/Tooltip/Tooltip.svelte
@@ -3,7 +3,6 @@
 	import { createEventDispatcher, onMount } from 'svelte';
 	import { Box } from '../Box';
 	import { Popper } from '../Popper';
-	import type { CSS } from '$lib/styles';
 	import type { TooltipProps as $$TooltipProps } from './Tooltip.styles';
 
 	interface $$Props extends $$TooltipProps {}
@@ -72,7 +71,7 @@
 	});
 
 	$: visible = (typeof opened === 'boolean' ? opened : _opened) && !disabled;
-	$: ({ cx, classes, getStyles } = useStyles({ color, radius }));
+	$: ({ cx, classes, getStyles } = useStyles({ color, radius }, { name: "Tooltip" }));
 </script>
 
 <Box
@@ -94,6 +93,7 @@
 		{withArrow}
 		{arrowSize}
 		{zIndex}
+    arrowClassName={classes.arrow}
 		reference={tooltipRefElement}
 		mounted={visible}
 		arrowDistance={3}

--- a/packages/svelteui-core/src/styles/engine/create-styles.ts
+++ b/packages/svelteui-core/src/styles/engine/create-styles.ts
@@ -52,7 +52,7 @@ function createRef(refName: string) {
 function sanitizeCss(object: DirtyObject, theme: SvelteUITheme) {
 	// builds this to map the generated class name to the class key
 	// given in the CSS object
-	let refs: string[] = [];
+	const refs: string[] = [];
 	const classMap = {};
 
 	const _sanitize = (obj: Record<string, any>) => {

--- a/packages/svelteui-core/src/styles/engine/create-styles.ts
+++ b/packages/svelteui-core/src/styles/engine/create-styles.ts
@@ -52,23 +52,23 @@ function createRef(refName: string) {
 function sanitizeCss(object: DirtyObject, theme: SvelteUITheme) {
 	// builds this to map the generated class name to the class key
 	// given in the CSS object
-  let refs: string[] = [];
+	let refs: string[] = [];
 	const classMap = {};
 
 	const _sanitize = (obj: Record<string, any>) => {
 		Object.keys(obj).map((value) => {
 			// transforms certain keywords into the correct CSS selectors
 			if (value === 'variants') return;
-      // saves the reference value so that later it can be added
-      // to reference the CSS selector
+			// saves the reference value so that later it can be added
+			// to reference the CSS selector
 			if (value === 'ref') {
-        refs.push(obj.ref as string);
-      }
+				refs.push(obj.ref as string);
+			}
 			if (value === 'darkMode') {
 				obj[`${theme.dark} &`] = obj.darkMode;
 			}
 
-      // returns the recursive call if the CSS is not an object
+			// returns the recursive call if the CSS is not an object
 			if (obj[value] === null || typeof obj[value] !== 'object') return;
 
 			// calls the sanitize method recursively so that it can sanitize
@@ -79,11 +79,10 @@ function sanitizeCss(object: DirtyObject, theme: SvelteUITheme) {
 			// to the correct CSS selector
 			if (value === 'darkMode') {
 				delete obj[value];
+			} else if (value.startsWith('@media')) {
+				// do nothing if its a @media selector
 			}
-			else if (value.startsWith('@media')) {
-        // do nothing if its a @media selector
-      }
-      // only adds the correct selectors if it has none
+			// only adds the correct selectors if it has none
 			else if (!value.startsWith('&') && !value.startsWith(theme.dark)) {
 				const getStyles = css(obj[value]);
 				classMap[value] = getStyles().toString();
@@ -128,7 +127,7 @@ export function createStyles<Key extends string = string, Params = void>(
 		// transforms the keys into strings to be consumed by the classes
 		const classes: Record<Key, string> = fromEntries(
 			Object.keys(dirtyCssObject).map((keys) => {
-        const ref = refs.find(r => r.includes(keys)) ?? '';
+				const ref = refs.find((r) => r.includes(keys)) ?? '';
 				const getRefName: string[] = ref?.split('-') ?? [];
 				const keyIsRef = ref?.split('-')[getRefName?.length - 1] === keys;
 				const value = keys.toString();

--- a/packages/svelteui-core/src/styles/engine/create-styles.ts
+++ b/packages/svelteui-core/src/styles/engine/create-styles.ts
@@ -6,6 +6,8 @@ import { useSvelteUITheme, useSvelteUIThemeContext } from '$lib/styles';
 import type { CSS } from '$lib/styles';
 import type { SvelteUITheme } from '$lib/styles';
 
+const CLASS_KEY = 'svelteui';
+
 type CreateRef = (refName: string) => string;
 
 type CSSObject = {
@@ -35,32 +37,63 @@ function createRef(refName: string) {
 	return `__svelteui-ref-${refName || ''}`;
 }
 
-function createSanitizedObject(object: DirtyObject, theme: SvelteUITheme, ref: string) {
-	Object.keys(object).map((value) => {
-		/** special key mapping */
-		if (value === 'variants') return;
-		if ('ref' in object[value]) ref = object[value].ref as string;
-		if ('darkMode' in object[value]) {
-			object[value][`${theme.dark} &`] = object[value].darkMode;
-		}
-		/** general key mapping */
-		object[`& .${value}`] = object[value];
+/**
+ * Sanitizes the provided CSS object, converting certain keywords to
+ * respective CSS selectors, transforms keys into generated CSS classes
+ * and returns the mapping between these generated classes and their initial
+ * keys.
+ *
+ * @param object The CSS object that has not yet been sanitized.
+ * @param theme The current theme object.
+ * @param ref The ref object.
+ * @returns The class map that maps the name of the key in the CSS object
+ * and the generated hash class.
+ */
+function sanitizeCss(object: DirtyObject, theme: SvelteUITheme, ref: string) {
+	// builds this to map the generated class name to the class key
+	// given in the CSS object
+	const classMap = {};
 
-		/** remove the old keys as they are not needed */
-		delete object[value];
-	});
-	/** delete the root property as it is not needed */
+	const _sanitize = (obj: Record<string, any>) => {
+		Object.keys(obj).map((value) => {
+			// returns the recursive call if the CSS is not an object
+			if (obj[value] === null || typeof obj[value] !== 'object') return;
+
+			// transforms certain keywords into the correct CSS selectors
+			if (value === 'variants') return;
+			if (value === 'ref') ref = obj.ref as string;
+			if (value === 'darkMode') {
+				obj[`${theme.dark} &`] = obj.darkMode;
+			}
+
+			// calls the sanitize method recursively so that it can sanitize
+			// all the style objects
+			_sanitize(obj[value]);
+
+			// removes the darkMode style since it has been switched
+			// to the correct CSS selector
+			if (value === 'darkMode') {
+				delete obj[value];
+			}
+			// only adds the correct selectors if it has none
+			else if (!value.startsWith('&') && !value.startsWith(theme.dark)) {
+				// obj[`& .${buildKey(value, name)}`] = obj[value];
+				const getStyles = css(obj[value]);
+				classMap[value] = getStyles().toString();
+				obj[`& .${getStyles().toString()}`] = obj[value];
+				delete obj[value];
+			}
+		});
+	};
+
+	_sanitize(object);
+
+	// deletes the root key since it won't be sanitized here
 	delete object['& .root'];
+
+	return classMap;
 }
 
-/**
- * custom made css-in-js styling function that is highly customizable and has many features
- *
- * allows you to subscribe to the current theme context
- *
- * @param getCssObjectOrCssObject - either an object of styles or a function that returns an object of styles
- * @returns
- */
 export function createStyles<Key extends string = string, Params = void>(
 	input:
 		| ((theme: SvelteUITheme, params: Params, createRef: CreateRef) => Record<Key, CSSObject>)
@@ -69,43 +102,49 @@ export function createStyles<Key extends string = string, Params = void>(
 	const getCssObject = typeof input === 'function' ? input : () => input;
 
 	function useStyles(params: Params = {} as Params, options?: UseStylesOptions<Key>) {
-		/** create our new theme object */
+		// uses the theme present in the current context or fallbacks to the default theme
 		const theme: SvelteUITheme = useSvelteUIThemeContext()?.theme || useSvelteUITheme();
 		const { cx } = cssFactory();
-		const { override } = options || {};
+
 		let ref: string;
+		const { override, name } = options || {};
+		const dirtyCssObject = getCssObject(theme, params, createRef);
 
-		/** store the created dirty object in a variable */
-		const cssObjectDirty: DirtyObject = getCssObject(theme, params, createRef);
-		/** clone the dirty object to modify it's properties */
-		const sanitizeObject = Object.assign({}, cssObjectDirty);
+		// builds the CSS object that contains transformed values
+		const sanitizedCss = Object.assign({}, dirtyCssObject);
+		const classMap = sanitizeCss(sanitizedCss, theme, ref, name);
 
-		/** takes all keys and maps them to the proper string values */
-		createSanitizedObject(sanitizeObject, theme, ref);
+		const { root } = dirtyCssObject;
+		const cssObjectClean = root !== undefined ? { ...root, ...sanitizedCss } : dirtyCssObject;
 
-		const { root } = cssObjectDirty;
-
-		/** create our clean object that will get passed to the css function */
-		const cssObjectClean = root !== undefined ? { ...root, ...sanitizeObject } : cssObjectDirty;
 		const getStyles = css(cssObjectClean);
 
-		/** transform keys from dirty object into strings to be consumed by classes */
+		// transforms the keys into strings to be consumed by the classes
 		const classes: Record<Key, string> = fromEntries(
-			Object.keys(cssObjectDirty).map((keys) => {
+			Object.keys(dirtyCssObject).map((keys) => {
 				const getRefName: string[] = ref?.split('-') ?? [];
 				const keyIsRef = ref?.split('-')[getRefName?.length - 1] === keys;
-				let value = keys.toString();
+				const value = keys.toString();
 
-				/** if we get a valid ref, then add that value to the array */
+				let transformedClasses = classMap[value] ?? value;
+
+				// add the value to the array if the ref provided is valid
 				if (ref && keyIsRef) {
-					value = `${value} ${ref}`;
+					transformedClasses = `${value} ${ref}`;
 				}
+				// generates the root styles, applying the override styles
 				if (keys === 'root') {
-					/** generate our styles */
-					value = getStyles({ css: override }).toString();
+					transformedClasses = getStyles({ css: override }).toString();
 				}
 
-				return [keys, value];
+				// adds a custom class that can be used to override style
+				let libClass = `${CLASS_KEY}-${keys.toString()}`;
+				if (name) {
+					libClass = `${CLASS_KEY}-${name}-${keys.toString()}`;
+					transformedClasses = `${transformedClasses} ${libClass}`;
+				}
+
+				return [keys, transformedClasses];
 			})
 		);
 

--- a/packages/svelteui-core/src/styles/engine/css.ts
+++ b/packages/svelteui-core/src/styles/engine/css.ts
@@ -4,6 +4,7 @@ export type ArgumentArray = Array<Argument>;
 export type Argument = Value | Mapping | ArgumentArray;
 
 const hasOwn = {}.hasOwnProperty;
+
 function cx(...args: ArgumentArray): string {
 	const classes = [];
 

--- a/packages/svelteui-demos/src/components/Configurator/controls/SizeControl.svelte
+++ b/packages/svelteui-demos/src/components/Configurator/controls/SizeControl.svelte
@@ -12,13 +12,7 @@
 		{ value: 100, label: 'xl' }
 	];
 
-  const values = [
-    "xs",
-    "sm",
-    "md",
-    "lg",
-    "xl"
-  ]
+	const values = ['xs', 'sm', 'md', 'lg', 'xl'];
 
 	const dispatch = createEventDispatcher();
 

--- a/packages/svelteui-demos/src/demos/composables/actions/use-move/usage.svelte
+++ b/packages/svelteui-demos/src/demos/composables/actions/use-move/usage.svelte
@@ -25,10 +25,10 @@
 	};
 </script>
 
-<script lang="ts" >
+<script lang="ts">
 	import { move } from '@svelteuidev/composables';
 
-  let moving = false;
+	let moving = false;
 	let position = { x: 0, y: 0 };
 	function handleMoveStart() {
 		moving = true;
@@ -41,19 +41,20 @@
 	}
 </script>
 
-
 <div
-  use:move
-  on:move:start={handleMoveStart}
-  on:move={handleMove}
-  on:move:stop={handleMoveStop}
-  style="position: relative; width: 90%; height: 200px; background-color: lightgrey; margin: 20px;"
+	use:move
+	on:move:start={handleMoveStart}
+	on:move={handleMove}
+	on:move:stop={handleMoveStop}
+	style="position: relative; width: 90%; height: 200px; background-color: lightgrey; margin: 20px;"
 >
-  <div
-    style="position: absolute; cursor: pointer; background-color: {moving ? 'green' : 'red'}; width: 20px; height: 20px; left: calc({position.x *
-      100}% - 10px); top: calc({position.y * 100}% - 10px);"
-  />
+	<div
+		style="position: absolute; cursor: pointer; background-color: {moving
+			? 'green'
+			: 'red'}; width: 20px; height: 20px; left: calc({position.x *
+			100}% - 10px); top: calc({position.y * 100}% - 10px);"
+	/>
 </div>
 <div style="text-align: center; margin-top: 10px;">
-  X: {position.x * 100}% Y: {position.y * 100}%
+	X: {position.x * 100}% Y: {position.y * 100}%
 </div>

--- a/packages/svelteui-demos/src/demos/core/Tabs/Tabs.demo.component.svelte
+++ b/packages/svelteui-demos/src/demos/core/Tabs/Tabs.demo.component.svelte
@@ -33,7 +33,7 @@
 		First tab content
 	</Tabs.Tab>
 	<Tabs.Tab label="Not allowed" disabled>https://youtu.be/dQw4w9WgXcQ</Tabs.Tab>
-	<Tabs.Tab label="Delete this?" color="red" override={{ fontWeight: 500 }}>
+	<Tabs.Tab label="Delete this?" color="red" override={{ backgroundColor: 'red' }}>
 		Yes, delete this
 	</Tabs.Tab>
 </Tabs>


### PR DESCRIPTION
### Improvement of `createStyles` util and API

* Support for classnames for each element of a component. Can be easily overriden. Ex: `svelteui-Timeline-root` - svelteui-Timeline-icon`, etc.
* It now transforms all `darkMode` keywords recursively (fixes the problem that it was only switched if only on one level deeper)
* It uses class names for references and correctly uses their class when they are referenced. Usage below:
```
{
   .root {
     ...
     [`& .${getRef('icon')}`]: { ... }
   }
   .icon {
      ref: getRef('icon'),
      ....
   }
}
```

Tested in storybook and in the docs and fixed any problems that happened due to these changes.

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `yarn lint` or just run `yarn repo:prepush` and check to see if it's passing.
