### PR TITLE
[@svelteui/core] Allow CSS pointer events in Popper

### DIFF
--- a/packages/svelteui-core/src/components/Popper/Popper.styles.ts
+++ b/packages/svelteui-core/src/components/Popper/Popper.styles.ts
@@ -73,7 +73,6 @@ export default createStyles((_, { arrowSize, zIndex }: PopperStyleParams) => {
 	return {
 		root: {
 			position: 'absolute',
-			pointerEvents: 'none',
 			zIndex: zIndex
 		},
 		arrowStyles: {


### PR DESCRIPTION
Solves https://github.com/svelteuidev/svelteui/issues/259 by removing the line of CSS that disables pointer events on the Popper.

It's unclear to me why pointer events are disabled, to begin with. Popper works perfectly fine with pointer-events enabled.  

Having the pointer-events allows having buttons and other interacting content inside the resulting popper container.

I'm unsure how to add reasonable tests for this change since it's a functional change but in CSS.

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [x] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.

### Tests

- [x] Run the tests with `npm test` and lint the project with `yarn lint` or just run `yarn repo:prepush` and check to see if it's passing.
