### PR TITLE
[@svelteuidev/core] #258: Make Anchor props optional and complete docs

### DIFF
--- a/apps/docs/src/pages/core/anchor.md
+++ b/apps/docs/src/pages/core/anchor.md
@@ -19,11 +19,13 @@ docs: 'core/anchor.md'
 
 ## Usage
 
-Anchor is a wrapper around the [Text](core/text.md) component that uses `a` as the root of the element. It supports the same props as the `Text` component.
+Anchor is a wrapper around the [Text](core/text.md) component that uses `a` as the root of the element. It supports the same props as the `Text` component. If the link is to be opened in another tab, the prop `external` must be set to `true`.
 
 <Demo demo={AnchorDemos.usage} />
 
 ## Usage with svelte-routing and other libraries
+
+It's possible to change the root of the component to use another, for example by using a Link component of a routing library. To do that, it's necessary to pass that component to the prop `root`.
 
 [svelte routing](https://github.com/EmilTholin/svelte-routing#readme)
 

--- a/packages/svelteui-core/src/components/Anchor/Anchor.styles.ts
+++ b/packages/svelteui-core/src/components/Anchor/Anchor.styles.ts
@@ -2,8 +2,8 @@ import { createStyles } from '$lib/styles';
 import type { TextProps } from '../Text/Text.styles';
 
 export interface AnchorProps extends TextProps {
-	root: TextProps['root'];
-	external: boolean;
+	root?: TextProps['root'];
+	external?: boolean;
 }
 
 export default createStyles(() => {


### PR DESCRIPTION
Fixes #258.
* Made the anchor props optional since they have default values
* Added mention of the `root` and `external` props to the docs

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `yarn lint` or just run `yarn repo:prepush` and check to see if it's passing.
