### PR TITLE
[@svelteui/core]: #172: function to inject Stitches stylesheet as a hook (fixes SSR FOUC)

### DIFF
--- a/apps/docs/src/pages/theming/ssr.md
+++ b/apps/docs/src/pages/theming/ssr.md
@@ -10,25 +10,6 @@ docs: 'theming/ssr.md'
     import { Prism } from "@svelteuidev/prism";
 
     const styles = `<style id='svelteui-inject-body' type='text/css'>.article>*:nth-child(3){margin-top:15rem!important;}@media(max-width: 800px){.article>*:nth-child(3){margin-top:18rem!important;}}<\/style>`;
-
-    const step1 = `
-    <script>
-        import { SvelteUIProvider } from '@svelteuidev/core';
-    <\/script>
-
-    <SvelteUIProvider>
-        <slot />
-    <\/SvelteUIProvider>
-    `
-    const step2 = `
-    <script>
-        import { SvelteUIProvider } from '@svelteuidev/core';
-    <\/script>
-
-    <SvelteUIProvider ssr>
-        <slot />
-    <\/SvelteUIProvider>
-    `
 </script>
 
 <svelte:head>
@@ -57,14 +38,10 @@ In your top level `+layout.svelte` file, wrap your app in the SvelteUIProvider c
 
 ## 2.
 
-Once you've wrapped your application in the provider, all you need to do is add the `ssr` prop to it and boom! The `ssr` prop will give you all the CSS you need to server-side render your styles:
+In the file `hooks.server.(js|ts)` in your SvelteKit app (see [SK docs](https://kit.svelte.dev/docs/hooks)), add the code below. With this, the CSS will be injected to the page before sending it to the client.
 
-```svelte
-<script>
-	import { SvelteUIProvider } from '@svelteuidev/core';
-</script>
+```typescript
+import { prepareStylesSSR } from '@svelteuidev/core';
 
-<SvelteUIProvider ssr>
-	<slot />
-</SvelteUIProvider>
+export const handle = prepareStylesSSR;
 ```

--- a/packages/svelteui-core/src/styles/index.ts
+++ b/packages/svelteui-core/src/styles/index.ts
@@ -1,5 +1,6 @@
 export * from './theme/index.js';
 export * from './engine/index.js';
+export * from './ssr.js';
 
 export {
 	css,

--- a/packages/svelteui-core/src/styles/ssr.ts
+++ b/packages/svelteui-core/src/styles/ssr.ts
@@ -1,0 +1,22 @@
+import { getCssText } from '../stitches.config';
+
+/**
+ * Injects the stitches stylesheet at the end of the
+ * <head> of the DOM so that the stylesheet can be loaded
+ * in page render for SSR.
+ *
+ * This needs to be setup on the 'handle' server hook in hooks.server.(js|ts).
+ * @see https://kit.svelte.dev/docs/hooks#server-hooks
+ */
+export const prepareStylesSSR = async ({ event, resolve }) => {
+	return await resolve(event, {
+		transformPageChunk: ({ html }) => {
+			const headEndIndex = html.indexOf('</head>');
+			const returnHtml =
+				html.slice(0, headEndIndex) +
+				`<style id="stitches">${getCssText()}</style>` +
+				html.slice(headEndIndex);
+			return returnHtml;
+		}
+	});
+};

--- a/packages/svelteui-core/src/styles/theme/SvelteUIProvider/SvelteUIProvider.svelte
+++ b/packages/svelteui-core/src/styles/theme/SvelteUIProvider/SvelteUIProvider.svelte
@@ -4,7 +4,7 @@
 	import { mergeTheme } from '../';
 	import { useSvelteUITheme } from './default-theme';
 	import { colorScheme } from './svelteui.stores';
-	import { key, ssrStyles, useSvelteUIThemeContext } from './svelteui.provider';
+	import { key, useSvelteUIThemeContext } from './svelteui.provider';
 	import { createStyles, dark, getCssText, NormalizeCSS, SvelteUIGlobalCSS } from '../../index';
 	import { createEventForwarder, useActions } from '$lib/internal';
 	import type { SvelteUITheme } from '../types';
@@ -22,7 +22,6 @@
 		themeObserver: $$SvelteUIProviderProps['themeObserver'] = 'light',
 		withNormalizeCSS: $$SvelteUIProviderProps['withNormalizeCSS'] = false,
 		withGlobalStyles: $$SvelteUIProviderProps['withGlobalStyles'] = false,
-		ssr: $$SvelteUIProviderProps['ssr'] = false,
 		override: $$SvelteUIProviderProps['override'] = {},
 		inherit: $$SvelteUIProviderProps['inherit'] = false;
 	export { className as class };
@@ -58,12 +57,6 @@
 	$: mergedTheme = mergeTheme(DEFAULT_THEME, overrides.themeOverride);
 	$: ({ cx, classes } = useStyles(null, { override }));
 </script>
-
-<svelte:head>
-	{#if ssr}
-		{@html ssrStyles(getCssText)}
-	{/if}
-</svelte:head>
 
 <div
 	id="SVELTEUI_PROVIDER"

--- a/packages/svelteui-core/src/styles/theme/SvelteUIProvider/index.ts
+++ b/packages/svelteui-core/src/styles/theme/SvelteUIProvider/index.ts
@@ -3,7 +3,6 @@ export { useSvelteUITheme } from './default-theme';
 export { colorScheme } from './svelteui.stores';
 export {
 	key,
-	ssrStyles,
 	globalStyles,
 	useSvelteUIDefaultProps,
 	useSvelteUIThemeContext

--- a/packages/svelteui-core/src/styles/theme/SvelteUIProvider/svelteui.provider.ts
+++ b/packages/svelteui-core/src/styles/theme/SvelteUIProvider/svelteui.provider.ts
@@ -21,7 +21,6 @@ export interface SvelteUIProviderProps extends DefaultProps<HTMLDivElement> {
 	themeObserver?: ColorScheme;
 	withNormalizeCSS?: boolean;
 	withGlobalStyles?: boolean;
-	ssr?: boolean;
 	inherit?: boolean;
 }
 
@@ -34,10 +33,6 @@ export const globalStyles = (themeObserver: ColorScheme): string => {
 	const globalStylesDark = `<style\tid="svelteui-inject" type="text\/css">body{background-color:#1A1B1E;color:#C1C2C5;}<\/style>`;
 	if (themeObserver === 'light') return globalStylesLight;
 	return globalStylesDark;
-};
-
-export const ssrStyles = (fn: () => string): string => {
-	return `<style\tid="stitches">${fn()}<\/style>`;
 };
 
 export function useSvelteUIThemeContext(): SvelteUIProviderContextType {


### PR DESCRIPTION
Related to #172.

Pinging @impactvelocity since it's his solution and his opinion would be appreciated.
I'm not sure this is the best solution, leaving this here to open the discussion.

The current implementation would require that a user that wants to use SvelteUI with SSR would need to add to it's `hooks.server.ts` something like:

```
import { prepareStylesSSR } from '@svelteuidev/core';

export const handle = prepareStylesSSR;
``` 

or ```export const handle =  sequence(prepareStylesSSR); // if necessary to have more than one operation```.

Changes made:
* New util to add to hooks.server that allow correct loading of styles for SSR
* Removed `ssr` prop from SvelteUIProvider - the only way of doing SSR is with the approach above 
* Updated docs

Disclaimer: I'm no expert on this, would like some other opinions, I have yet to use hooks extensively in my personal projects yet.

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `yarn lint` or just run `yarn repo:prepush` and check to see if it's passing.
