### PR TITLE
[@svelteui/core]: Add slots for icon and label in `Tabs.Tab`

### DIFF
--- a/apps/docs/src/pages/core/tabs.md
+++ b/apps/docs/src/pages/core/tabs.md
@@ -64,7 +64,7 @@ Tabs positioning is controlled with the `grow` and `position` props. If the `gro
 
 ## Tab component props
 
-In addition to the `icon` and `label` props shown before, the `Tabs.Tab` component accepts `color`, `disabled` and any other props from a regular button (e.g. `style`, `title`, `aria-`, `data-`). The `color` prop will override the `color` defined in the `Tabs` component.
+In addition to the `icon` and `label` props shown before, the `Tabs.Tab` component accepts `color`, `disabled` and any other props from a regular button (e.g. `style`, `title`, `aria-`, `data-`). The `color` prop will override the `color` defined in the `Tabs` component. The `Tabs.Tab` icon and label can also be overridden using the slots with those names.
 
 <Demo demo={TabsDemos.component} />
 

--- a/packages/svelteui-core/src/components/Tabs/Tab/Tab.svelte
+++ b/packages/svelteui-core/src/components/Tabs/Tab/Tab.svelte
@@ -60,12 +60,16 @@
 	{...$$restProps}
 >
 	<div class={classes.inner}>
-		{#if icon}
-			<IconRenderer {icon} className={classes.icon} />
-		{/if}
-		{#if label}
-			<div class={classes.label}>{label}</div>
-		{/if}
+		<slot name="icon">
+			{#if icon}
+				<IconRenderer {icon} className={classes.icon} />
+			{/if}
+		</slot>
+    <slot name="label">
+      {#if label}
+        <div class={classes.label}>{label}</div>
+      {/if}
+    </slot>
 		<div class={cx('svelteui-tab-content', classes.tabContent)}>
 			<slot />
 		</div>

--- a/packages/svelteui-core/src/components/Tabs/Tabs.stories.svelte
+++ b/packages/svelteui-core/src/components/Tabs/Tabs.stories.svelte
@@ -2,6 +2,7 @@
 	import { Meta, Template, Story } from '@storybook/addon-svelte-csf';
 	import { Camera, EnvelopeClosed, Gear } from 'radix-icons-svelte';
 	import { Tabs } from './index';
+	import { Badge } from '../Badge';
 </script>
 
 <Meta title="Components/Tabs" component={Tabs} />
@@ -15,3 +16,14 @@
 </Template>
 
 <Story name="Tabs" id="tabs" />
+
+<Story name="Tabs using icon slot" id="tabs_slot">
+	<Tabs>
+		<Tabs.Tab label="Gallery">
+			<svelte:fragment slot="icon">
+				<Badge>New</Badge>
+			</svelte:fragment>
+			Gallery tab content
+		</Tabs.Tab>
+	</Tabs>
+</Story>


### PR DESCRIPTION
* Added slot for icon and label in `Tabs.Tab`.

Feature request mentioned in Discord - https://discord.com/channels/954790377754337280/959831408988266506/1057663327343484958

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `yarn lint` or just run `yarn repo:prepush` and check to see if it's passing.
