### PR TITLE
[@svelteui/core]: change ChipGroup `value` type based on `multiple` prop value

### DIFF
--- a/packages/svelteui-core/src/components/Chip/Chip.svelte
+++ b/packages/svelteui-core/src/components/Chip/Chip.svelte
@@ -15,7 +15,7 @@
 		color: $$Props['color'] = 'blue',
 		id: $$Props['id'] = randomID(),
 		disabled: $$Props['disabled'] = false,
-		value: $$Props['value'] = null,
+		value: $$Props['value'] = undefined,
 		checked: $$Props['checked'] = false,
 		label: $$Props['label'] = '',
 		radius: $$Props['radius'] = 'xl',

--- a/packages/svelteui-core/src/components/Chip/ChipGroup/ChipGroup.stories.svelte
+++ b/packages/svelteui-core/src/components/Chip/ChipGroup/ChipGroup.stories.svelte
@@ -79,6 +79,7 @@
 <Story name="Input label">
 	<ChipGroup
 		bind:value={bindValue}
+    multiple
 		label="Pick as many as you like"
 		items={[
 			{ label: 'One', value: 'one' },

--- a/packages/svelteui-core/src/components/Chip/ChipGroup/ChipGroup.styles.ts
+++ b/packages/svelteui-core/src/components/Chip/ChipGroup/ChipGroup.styles.ts
@@ -7,12 +7,12 @@ import type {
 } from '$lib/styles';
 import type { GroupPosition } from '../../Group';
 
-export interface ChipGroupProps extends DefaultProps {
+export interface ChipGroupProps<T = boolean> extends DefaultProps {
 	color?: SvelteUIColor;
 	items?: { label: string; value: string }[];
-	value?: string[];
+	value?: T extends true ? string[] : string;
 	label?: string;
-	multiple?: boolean;
+	multiple?: T;
 	disabled?: boolean;
 	variant?: 'outline' | 'filled';
 	size?: SvelteUISize;

--- a/packages/svelteui-core/src/components/Chip/ChipGroup/ChipGroup.svelte
+++ b/packages/svelteui-core/src/components/Chip/ChipGroup/ChipGroup.svelte
@@ -11,10 +11,10 @@
 		className: $$Props['className'] = '',
 		override: $$Props['override'] = {},
 		color: $$Props['color'] = undefined,
-		items: $$Props['items'] = [],
-		value: $$Props['value'] = [],
-		label: $$Props['label'] = null,
 		multiple: $$Props['multiple'] = false,
+		items: $$Props['items'] = [],
+		value: $$Props['value'] = multiple ? [] : undefined,
+		label: $$Props['label'] = null,
 		disabled: $$Props['disabled'] = false,
 		variant: $$Props['variant'] = 'outline',
 		size: $$Props['size'] = undefined,
@@ -26,11 +26,11 @@
 	export { className as class };
 
 	function onChanged(item: string, el: EventTarget) {
-		if ((el as HTMLInputElement).checked) {
-			if (multiple) value = [...value, item];
-			else value = [item];
+		const checked = (el as HTMLInputElement).checked;
+		if (Array.isArray(value)) {
+			value = checked ? [...value, item] : value.filter((val) => val !== item);
 		} else {
-			value = value.filter((val) => val !== item);
+			value = checked ? item : undefined;
 		}
 	}
 </script>
@@ -57,7 +57,7 @@ A chip group component is a container for Chips.
 				{use}
 				label={item.label}
 				value={item.value}
-				checked={value.includes(item.value)}
+				checked={Array.isArray(value) ? value.includes(item.value) : value === item.value}
 				{radius}
 				{size}
 				{color}

--- a/packages/svelteui-core/src/components/Tabs/Tab/Tab.svelte
+++ b/packages/svelteui-core/src/components/Tabs/Tab/Tab.svelte
@@ -65,11 +65,11 @@
 				<IconRenderer {icon} className={classes.icon} />
 			{/if}
 		</slot>
-    <slot name="label">
-      {#if label}
-        <div class={classes.label}>{label}</div>
-      {/if}
-    </slot>
+		<slot name="label">
+			{#if label}
+				<div class={classes.label}>{label}</div>
+			{/if}
+		</slot>
 		<div class={cx('svelteui-tab-content', classes.tabContent)}>
 			<slot />
 		</div>


### PR DESCRIPTION
Prop `value` in `ChipGroup` will be `string[]` if `multiple` is true and `string` if `multiple` is false.

Originated from https://discord.com/channels/954790377754337280/959831408988266506/1058327568031436801

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [x] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.

### Tests

- [x] Run the tests with `npm test` and lint the project with `yarn lint` or just run `yarn repo:prepush` and check to see if it's passing.
