### PR TITLE
[@svelteui/core]: Tabs.Tab `iconProps` prop

### DIFF
--- a/apps/docs/src/pages/core/tabs.md
+++ b/apps/docs/src/pages/core/tabs.md
@@ -64,7 +64,7 @@ Tabs positioning is controlled with the `grow` and `position` props. If the `gro
 
 ## Tab component props
 
-In addition to the `icon` and `label` props shown before, the `Tabs.Tab` component accepts `color`, `disabled` and any other props from a regular button (e.g. `style`, `title`, `aria-`, `data-`). The `color` prop will override the `color` defined in the `Tabs` component. The `Tabs.Tab` icon and label can also be overridden using the slots with those names.
+In addition to the `icon` and `label` props shown before, the `Tabs.Tab` component accepts `color`, `disabled` and any other props from a regular button (e.g. `style`, `title`, `aria-`, `data-`). The `color` prop will override the `color` defined in the `Tabs` component. The `Tabs.Tab` icon and label can also be overridden using the slots with those names. To modify the styles of the icons, props to them can be provided with the prop `iconProps`.
 
 <Demo demo={TabsDemos.component} />
 

--- a/packages/svelteui-core/src/components/Chip/ChipGroup/ChipGroup.stories.svelte
+++ b/packages/svelteui-core/src/components/Chip/ChipGroup/ChipGroup.stories.svelte
@@ -79,7 +79,7 @@
 <Story name="Input label">
 	<ChipGroup
 		bind:value={bindValue}
-    multiple
+		multiple
 		label="Pick as many as you like"
 		items={[
 			{ label: 'One', value: 'one' },

--- a/packages/svelteui-core/src/components/Tabs/Tab/Tab.styles.ts
+++ b/packages/svelteui-core/src/components/Tabs/Tab/Tab.styles.ts
@@ -6,6 +6,7 @@ import type { DefaultProps, SvelteUIColor, SvelteUITheme, VariantThemeFunction }
 export interface TabProps extends DefaultProps {
 	active?: boolean;
 	icon?: Component | HTMLOrSVGElement;
+	iconProps?: Record<string, unknown>;
 	label?: Component | string;
 	color?: SvelteUIColor;
 	variant?: TabsVariant;

--- a/packages/svelteui-core/src/components/Tabs/Tab/Tab.svelte
+++ b/packages/svelteui-core/src/components/Tabs/Tab/Tab.svelte
@@ -15,6 +15,7 @@
 		override: $$Props['override'] = {},
 		active: $$Props['active'] = undefined,
 		icon: $$Props['icon'] = undefined,
+		iconProps: $$Props['iconProps'] = undefined,
 		label: $$Props['label'] = undefined,
 		color: $$Props['color'] = undefined,
 		variant: $$Props['variant'] = undefined,
@@ -60,9 +61,9 @@
 	{...$$restProps}
 >
 	<div class={classes.inner}>
-		<slot name="icon">
+		<slot name="icon" {color} {...iconProps}>
 			{#if icon}
-				<IconRenderer {icon} className={classes.icon} />
+				<IconRenderer {icon} {iconProps} className={classes.icon} />
 			{/if}
 		</slot>
 		<slot name="label">


### PR DESCRIPTION
Related to https://github.com/svelteuidev/svelteui/pull/264?notification_referrer_id=NT_kwDOAYiKkrM1MTk1MzY3NzI2OjI1NzI1NTg2#issuecomment-1368184903.

- New prop `iconProps` in `Tabs.Tab` that allows passing props to IconRenderer (like color, etc).

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `yarn lint` or just run `yarn repo:prepush` and check to see if it's passing.
