### PR TITLE
[@svelteui/core]: Fixes #275: temporary fix for passing HTML attributes to components

### DIFF
--- a/packages/svelteui-core/src/components/Button/Button.styles.ts
+++ b/packages/svelteui-core/src/components/Button/Button.styles.ts
@@ -1,13 +1,16 @@
 import { createStyles, vFunc } from '$lib/styles';
 import type {
+	DefaultProps,
+	ElementProps,
 	SvelteUIColor,
 	SvelteUINumberSize,
-	SvelteUIGradient,
-	DefaultProps
+	SvelteUIGradient
 } from '$lib/styles';
 import type { LoaderPropsExtended } from '../Loader/Loader.styles';
 
-export interface ButtonProps extends DefaultProps<HTMLButtonElement | HTMLAnchorElement> {
+export interface ButtonProps
+	extends DefaultProps<HTMLButtonElement | HTMLAnchorElement>,
+		Omit<ElementProps<HTMLButtonElement | HTMLAnchorElement>, 'loading'> {
 	variant?: ButtonVariant;
 	color?: SvelteUIColor;
 	size?: SvelteUINumberSize;

--- a/packages/svelteui-core/src/components/IconRenderer/IconRenderer.svelte
+++ b/packages/svelteui-core/src/components/IconRenderer/IconRenderer.svelte
@@ -10,8 +10,8 @@
 		iconSize: $$Props['iconSize'] = 16,
 		iconProps: $$Props['iconProps'] = {};
 
-  // Verifies if CSR only elements are defined, or else it won't use them
-  const requiresShim = typeof HTMLElement === "undefined" && typeof SVGElement === "undefined";
+	// Verifies if CSR only elements are defined, or else it won't use them
+	const requiresShim = typeof HTMLElement === 'undefined' && typeof SVGElement === 'undefined';
 
 	$: ({ cx, getStyles, classes } = useStyles({ iconSize }));
 	$: if (!requiresShim && (icon instanceof HTMLElement || icon instanceof SVGElement)) {
@@ -26,9 +26,9 @@
 		{...iconProps}
 	/>
 {:else if !requiresShim}
-  {#if icon instanceof HTMLElement || icon instanceof SVGElement}
-    <span class={cx(className, getStyles({ css: override }))}>
-      {@html icon.outerHTML}
-    </span>
-  {/if}
+	{#if icon instanceof HTMLElement || icon instanceof SVGElement}
+		<span class={cx(className, getStyles({ css: override }))}>
+			{@html icon.outerHTML}
+		</span>
+	{/if}
 {/if}

--- a/packages/svelteui-core/src/components/Input/Input.styles.ts
+++ b/packages/svelteui-core/src/components/Input/Input.styles.ts
@@ -1,8 +1,10 @@
 import { createStyles } from '$lib/styles';
-import type { DefaultProps, SvelteUINumberSize, SvelteUISize } from '$lib/styles';
+import type { DefaultProps, ElementProps, SvelteUINumberSize, SvelteUISize } from '$lib/styles';
 import type { Component } from '$lib/internal';
 
-export interface InputBaseProps extends DefaultProps {
+export interface InputBaseProps
+	extends DefaultProps<HTMLInputElement>,
+		ElementProps<HTMLInputElement> {
 	icon?: Component | HTMLOrSVGElement;
 	iconWidth?: number;
 	iconProps?: { size: number; color: 'currentColor' | string };

--- a/packages/svelteui-core/src/components/TextInput/TextInput.styles.ts
+++ b/packages/svelteui-core/src/components/TextInput/TextInput.styles.ts
@@ -2,6 +2,6 @@ import type { Override } from '$lib/styles';
 import type { InputProps } from '../Input/Input.styles';
 import type { InputWrapperProps } from '../InputWrapper/InputWrapper.styles';
 
-export interface TextInputProps extends InputProps, InputWrapperProps {
+export interface TextInputProps extends InputProps, Omit<InputWrapperProps, 'element' | 'size'> {
 	overrideInput?: Override['props'];
 }

--- a/packages/svelteui-core/src/components/TextInput/TextInput.svelte
+++ b/packages/svelteui-core/src/components/TextInput/TextInput.svelte
@@ -84,6 +84,7 @@ Input for text that also uses labels for the input
 		{size}
 		id={baseId}
 		{placeholder}
+		{...overrideInput}
 		{...$$restProps}
 		use={[forwardEvents, [useActions, use]]}
 		invalid={_invalid}

--- a/packages/svelteui-core/src/styles/theme/types/DefaultProps.ts
+++ b/packages/svelteui-core/src/styles/theme/types/DefaultProps.ts
@@ -13,11 +13,13 @@ export interface DefaultProps<T = HTMLElement> extends SvelteUIStyleSystemProps 
 	use?: ActionArray;
 }
 
+export interface ElementProps<T extends EventTarget>
+	extends Omit<svelte.JSX.HTMLAttributes<T>, 'size'> {}
+
 /* Default Props to be used everywhere. Here in the same spot to copy
 
 export let use: $$BLANK-Props['use'] = [],
 		element: $$BLANK-Props['element'] = undefined,
 		className: $$BLANK-Props['className'] = '',
-		override: $$BLANK-Props['override'] = {},
-
+		override: $$BLANK-Props['override'] = {}
 */

--- a/packages/svelteui-core/src/styles/theme/types/index.ts
+++ b/packages/svelteui-core/src/styles/theme/types/index.ts
@@ -1,5 +1,5 @@
 export type { DeepPartial } from './DeepPartial';
-export type { DefaultProps } from './DefaultProps';
+export type { DefaultProps, ElementProps } from './DefaultProps';
 export type { ColorScheme, DefaultBackground, DefaultColor } from './ColorScheme';
 export type { SvelteUIColor } from './SvelteUIColor';
 export type { SvelteUIGradient } from './SvelteUIGradient';


### PR DESCRIPTION
Fixes #275 in some components. A new migration to [component typings](https://github.com/sveltejs/language-tools/blob/master/docs/preprocessors/typescript.md#typing-components-authoring-packages) will be made.


### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `yarn lint` or just run `yarn repo:prepush` and check to see if it's passing.
