### PR TITLE
[@svelteui/core] Fixes #277: Native select change event being called before the value is changed

### DIFF
--- a/packages/svelteui-core/src/components/Input/Input.svelte
+++ b/packages/svelteui-core/src/components/Input/Input.svelte
@@ -109,25 +109,26 @@ Base component to create custom inputs
 			{...$$restProps}
 		/>
 	{:else if isHTMLElement}
-		<!-- prettier-ignore -->
+		<!-- on:change needs to appear before use:forwardEvents so that the
+    ordering of the events is correct and the value is updated before propagation -->
 		<svelte:element
-			bind:this={element}
 			this={castRoot()}
-			value={value}
-			use:useActions={use}
-			use:forwardEvents
+			bind:this={element}
+			{value}
 			on:change={onChange}
 			{required}
 			{disabled}
 			{id}
-      {autocomplete}
+			{autocomplete}
 			aria-invalid={invalid}
 			class:disabled
 			class:invalid
 			class:withIcon={icon}
 			class={cx(className, classes.input, `${variant}Variant`)}
+			use:useActions={use}
+			use:forwardEvents
 			{...$$restProps}
-			>
+		>
 			<slot />
 		</svelte:element>
 	{:else if isComponent}

--- a/packages/svelteui-core/src/components/NativeSelect/NativeSelect.stories.svelte
+++ b/packages/svelteui-core/src/components/NativeSelect/NativeSelect.stories.svelte
@@ -12,9 +12,6 @@
 		label="Select your favorite framework/library"
 		description="This is anonymous"
 		{...args}
-		on:change={(e) => {
-			console.log(e.target.value);
-		}}
 	/>
 </Template>
 

--- a/packages/svelteui-core/src/components/TextInput/TextInput.svelte
+++ b/packages/svelteui-core/src/components/TextInput/TextInput.svelte
@@ -3,7 +3,7 @@
 	import { get_current_component } from 'svelte/internal';
 	import { InputWrapper } from '../InputWrapper';
 	import { Input } from '../Input';
-  import { randomID } from '$lib/styles';
+	import { randomID } from '$lib/styles';
 	import type { TextInputProps as $$TextInputProps } from './TextInput.styles';
 
 	interface $$Props extends $$TextInputProps {}
@@ -31,7 +31,7 @@
 
 	/** An action that forwards inner dom node events from parent component */
 	const forwardEvents = createEventForwarder(get_current_component());
-  const baseId = randomID(id)
+	const baseId = randomID(id);
 	// Flag that enables the override of the right section slot
 	// of the Input component only if it was provided
 	const _showRightSection =

--- a/packages/svelteui-core/src/components/Title/Title.stories.svelte
+++ b/packages/svelteui-core/src/components/Title/Title.stories.svelte
@@ -6,9 +6,7 @@
 <Meta title="Components/Title" component={Title} />
 
 <Template let:args>
-	<Title {...args}>
-		Title Storybook
-	</Title>
+	<Title {...args}>Title Storybook</Title>
 </Template>
 
 <Story name="Title" />


### PR DESCRIPTION
Fixes #277.

The `use:forwardEvents` was propagating the event before the on:change call that changes the value, switching the order solved it.

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `yarn lint` or just run `yarn repo:prepush` and check to see if it's passing.
