### PR TITLE
[@svelteui/core]: remove aria-required from NativeSelect

### DIFF
--- a/packages/svelteui-core/src/components/NativeSelect/NativeSelect.svelte
+++ b/packages/svelteui-core/src/components/NativeSelect/NativeSelect.svelte
@@ -94,7 +94,6 @@ Capture user feedback limited to large set of options
 		autocomplete="off"
 		invalid={Boolean(error)}
 		override={{ ...base, ...inputStyle }}
-		aria-required={required}
 		{size}
 		{icon}
 		{radius}


### PR DESCRIPTION
This PR fixes #283.

As pointed out in the related issue, it should use only `required` and not `aria-required`.

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `yarn lint` or just run `yarn repo:prepush` and check to see if it's passing.
