### PR TITLE
[@svelteui/core] support types other than 'text' in `Input`

### DIFF
--- a/packages/svelteui-core/src/components/IconRenderer/IconRenderer.svelte
+++ b/packages/svelteui-core/src/components/IconRenderer/IconRenderer.svelte
@@ -15,7 +15,7 @@
 
 	$: ({ cx, getStyles, classes } = useStyles({ iconSize }, { name: 'IconRenderer' }));
 	$: if (!requiresShim && (icon instanceof HTMLElement || icon instanceof SVGElement)) {
-		icon.classList.add(...classes.icon.split(" "));
+		icon.classList.add(...classes.icon.split(' '));
 	}
 </script>
 

--- a/packages/svelteui-core/src/components/Input/Input.d.ts
+++ b/packages/svelteui-core/src/components/Input/Input.d.ts
@@ -10,7 +10,7 @@ type InputElementType =
 	| HTMLTextAreaElement
 	| HTMLDataListElement;
 
-export interface InputBaseProps extends DefaultProps<InputElementType> {
+export interface InputBaseProps<T = string> extends DefaultProps<InputElementType> {
 	icon?: Component | HTMLOrSVGElement;
 	iconWidth?: number;
 	iconProps?: { size: number; color: 'currentColor' | string };
@@ -26,7 +26,7 @@ export interface InputBaseProps extends DefaultProps<InputElementType> {
 	disabled?: boolean;
 	size?: SvelteUISize;
 	root?: Component | keyof HTMLElementTagNameMap;
-	value?: string;
+	value?: T;
 }
 
 interface InputPropsInternal extends InputBaseProps {

--- a/packages/svelteui-core/src/components/Input/Input.stories.svelte
+++ b/packages/svelteui-core/src/components/Input/Input.stories.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { Meta, Template, Story } from '@storybook/addon-svelte-csf';
+	import { Input } from './index';
+
+	let value = 'Hello';
+	let valueNumber = 0;
+</script>
+
+<Meta title="Components/Input" component={Input} />
+
+<Template>
+	<Input bind:value />
+	{value}
+	{typeof value}
+</Template>
+
+<Story name="Input" id="input" />
+
+<Story name="Input as a number" id="inputNumber">
+	<Input bind:value={valueNumber} type="number" />
+	{valueNumber}
+	{typeof valueNumber}
+</Story>

--- a/packages/svelteui-core/src/components/Input/Input.svelte
+++ b/packages/svelteui-core/src/components/Input/Input.svelte
@@ -30,7 +30,8 @@
 		invalid: $$Props['invalid'] = false,
 		multiline: $$Props['multiline'] = false,
 		autocomplete: $$Props['autocomplete'] = 'on',
-		placeholder: $$Props['placeholder'] = '';
+		type: $$Props['type'] = 'text',
+		placeholder: $$Props['placeholder'] = undefined;
 	export { className as class };
 
 	/** An action that forwards inner dom node events from parent component */
@@ -51,6 +52,16 @@
 		// the 'this' keyword in this case is the
 		// HTML element provided in prop 'root'
 		value = this.value;
+	}
+
+	function onInput(event) {
+		if (event.target.type === 'checkbox') {
+			value = event.target.checked;
+		} else if (event.target.type === 'number' || event.target.type === 'range') {
+			value = +event.target.value;
+		} else {
+			value = event.target.value;
+		}
 	}
 
 	$: {
@@ -101,7 +112,8 @@ Base component to create custom inputs
 	{/if}
 	{#if isHTMLElement && root === 'input'}
 		<input
-			bind:value
+			{value}
+			{type}
 			bind:this={element}
 			use:useActions={use}
 			use:forwardEvents
@@ -121,6 +133,7 @@ Base component to create custom inputs
 				`${variant}Variant`
 			)}
 			{...$$restProps}
+			on:input={onInput}
 		/>
 	{:else if isHTMLElement && isInput(String(root))}
 		<!-- on:change needs to appear before use:forwardEvents so that the
@@ -134,6 +147,7 @@ Base component to create custom inputs
 			{disabled}
 			{id}
 			{autocomplete}
+      {type}
 			aria-invalid={invalid}
 			class:disabled
 			class:invalid
@@ -165,6 +179,7 @@ Base component to create custom inputs
 			{disabled}
 			{required}
 			{id}
+			{type}
 			{...$$restProps}
 		>
 			<slot />

--- a/packages/svelteui-demos/src/demos/core/Timeline/Timeline.demo.component.svelte
+++ b/packages/svelteui-demos/src/demos/core/Timeline/Timeline.demo.component.svelte
@@ -63,9 +63,7 @@
 		</Timeline.Item>
 		<Timeline.Item title="Image">
 			<svelte:fragment slot="bullet">
-				<Image
-					src="https://avatars.githubusercontent.com/u/1024025?v=4"
-				/>
+				<Image src="https://avatars.githubusercontent.com/u/1024025?v=4" />
 			</svelte:fragment>
 			<Text color="dimmed" size="sm">Item with bullet as image</Text>
 		</Timeline.Item>


### PR DESCRIPTION
Originated from https://discord.com/channels/954790377754337280/1069668539658682409

`Input` only supported `type=text`, which should not be since this is a component that should mirror the behaviour of the `<input>` DOM element.
Since it's not possible to do two-way binding of value when changing the `type` of the input (see links below), the `on:input` binding had to do this manually.

https://stackoverflow.com/questions/57392773/error-type-attribute-cannot-be-dynamic-if-input-uses-two-way-binding
https://github.com/sveltejs/svelte/issues/3921

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `yarn lint` or just run `yarn repo:prepush` and check to see if it's passing.
