### PR TITLE
[@svelteui/core]: fix tabs vertical orientation flex

### DIFF
--- a/packages/svelteui-core/src/components/Tabs/Tabs.stories.svelte
+++ b/packages/svelteui-core/src/components/Tabs/Tabs.stories.svelte
@@ -1,23 +1,65 @@
 <script lang="ts">
 	import { Meta, Template, Story } from '@storybook/addon-svelte-csf';
 	import { Camera, EnvelopeClosed, Gear } from 'radix-icons-svelte';
-	import { Tabs } from './index';
 	import { Badge } from '../Badge';
+	import { Image } from '../Image';
+	import { SimpleGrid } from '../SimpleGrid';
+	import { Text } from '../Text';
+	import { Title } from '../Title';
+	import { Tabs } from './index';
 </script>
 
 <Meta title="Components/Tabs" component={Tabs} />
 
 <Template let:args>
 	<Tabs {...args}>
-		<Tabs.Tab label="Gallery" icon={Camera}>Gallery tab content</Tabs.Tab>
-		<Tabs.Tab label="Messages" icon={EnvelopeClosed}>Messages tab content</Tabs.Tab>
+		<Tabs.Tab label="Gallery" icon={Camera}>
+			<Title align="left" mb="lg" order={3}>Your photos</Title>
+			<SimpleGrid cols={3}>
+				{#each Array(9) as i}
+					<Image src="https://cataas.com/cat" />
+				{/each}
+			</SimpleGrid>
+		</Tabs.Tab>
+		<Tabs.Tab label="Messages" icon={EnvelopeClosed}>
+			<Title align="left" mb="lg" order={3}>Your messages</Title>
+			<Text
+				>Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor.
+				Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur
+				ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla
+				consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget,
+				arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu
+				pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean
+				vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac,
+				enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra
+				nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel
+				augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. Maecenas tempus,
+				tellus eget condimentum rhoncus, sem quam semper libero, sit amet adipiscing sem neque sed
+				ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, lorem. Maecenas nec odio
+				et ante tincidunt tempus. Donec vitae sapien ut libero venenatis faucibus. Nullam quis ante.
+				Etiam sit amet orci eget eros faucibus tincidunt. Duis leo. Sed fringilla mauris sit amet
+				nibh. Donec sodales sagittis magna. Sed consequat, leo eget bibendum sodales, augue velit
+				cursus nunc, quis gravida magna mi a libero. Fusce vulputate eleifend sapien. Vestibulum
+				purus quam, scelerisque ut, mollis sed, nonummy id, metus. Nullam accumsan lorem in dui.
+				Cras ultricies mi eu turpis hendrerit fringilla. Vestibulum ante ipsum primis in faucibus
+				orci luctus et ultrices posuere cubilia Curae; In ac dui quis mi consectetuer lacinia. Nam
+				pretium turpis et arcu. Duis arcu tortor, suscipit eget, imperdiet nec, imperdiet iaculis,
+				ipsum. Sed aliquam ultrices mauris. Integer ante arcu, accumsan a, consectetuer eget,
+				posuere ut, mauris. Praesent adipiscing. Phasellus ullamcorper ipsum rutrum nunc. Nunc
+				nonummy metus. Vestibulum volutpat pretium libero. Cras id dui. Aenean ut eros et nisl
+				sagittis vestibulum. Nullam nulla eros, ultricies sit amet, nonummy id, imperdiet feugiat,
+				pede. Sed lectus. Donec mollis hendrerit risus. Phasellus nec sem in justo pellentesque
+				facilisis. Etiam imperdiet imperdiet orci. Nunc nec neque. Phasellus leo dolor, tempus non,
+				auctor et, hendrerit quis, nisi.</Text
+			>
+		</Tabs.Tab>
 		<Tabs.Tab label="Settings" icon={Gear}>Settings tab content</Tabs.Tab>
 	</Tabs>
 </Template>
 
 <Story name="Tabs" id="tabs" />
 
-<Story name="Tabs using icon slot" id="tabs_slot">
+<Story name="Tabs using icon slot" id="tabsSlot">
 	<Tabs>
 		<Tabs.Tab label="Gallery">
 			<svelte:fragment slot="icon">
@@ -27,3 +69,5 @@
 		</Tabs.Tab>
 	</Tabs>
 </Story>
+
+<Story name="Tabs in vertical orientation" id="tabsVertical" args={{ orientation: 'vertical' }} />

--- a/packages/svelteui-core/src/components/Tabs/Tabs.styles.ts
+++ b/packages/svelteui-core/src/components/Tabs/Tabs.styles.ts
@@ -60,6 +60,7 @@ export default createStyles((theme, { orientation, tabPadding }: TabsStyleParams
 				size: tabPadding,
 				sizes: theme.space
 			}),
+			flex: orientation === 'vertical' ? 1 : 'none',
 			display: 'block'
 		},
 		...getVariantStyles(orientation, theme, getRef)


### PR DESCRIPTION
Bug mentioned here: https://discord.com/channels/954790377754337280/1071565488066400347

- Added missing flex for tabs vertical orientation
- Added more stories to test this case

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [X] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.

### Tests

- [X] Run the tests with `npm test` and lint the project with `yarn lint` or just run `yarn repo:prepush` and check to see if it's passing.
