### PR TITLE
[@svelteui/core]: Use `default` variant in button when variant is not specified

### DIFF
--- a/packages/svelteui-core/src/components/Button/Button.stories.svelte
+++ b/packages/svelteui-core/src/components/Button/Button.stories.svelte
@@ -20,7 +20,8 @@
 	<div style="padding:40px;">
 		{#each colors as color}
 			<Group mt="xl">
-				<Button {color}>Filled button</Button>
+        <Button {color}>Default button</Button>
+				<Button {color} variant="filled">Filled button</Button>
 				<Button {color} variant="light">Light button</Button>
 				<Button {color} variant="outline">Outline button</Button>
 				<Button {color} variant="gradient">Gradient button</Button>

--- a/packages/svelteui-core/src/components/Button/Button.svelte
+++ b/packages/svelteui-core/src/components/Button/Button.svelte
@@ -14,7 +14,7 @@
 		element: $$Props['element'] = undefined,
 		className: $$Props['className'] = '',
 		override: $$Props['override'] = {},
-		variant: $$Props['variant'] = 'filled',
+		variant: $$Props['variant'] = 'default',
 		color: $$Props['color'] = 'blue',
 		size: $$Props['size'] = 'sm',
 		radius: $$Props['radius'] = 'sm',


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

Before submitting a PR, please read https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md

1. Give the PR a descriptive title
2. Ensure there is a related issue and it is referenced in the PR text
3. Ensure there are tests that cover the changes
4. Ensure that `yarn prepush` passes.

Happy contributing!

-->

## Description

<!--
Please write here a description of what this Pull Request added/changed.
Feel free to add screenshots/videos that illustrate the changes made.
-->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [x] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [x] Include a description of the changes made in the PR description and in the commit messages.
- [ ] Include screenshots/videos of the changes made.
- [x] Verify that the linter and tests are passing, with `yarn lint` and `yarn test` or just run `yarn prepush`.

The current button uses the `filled` variant when the variant prop is not given. As pointed by @piersg in #357, it should instead use the `default` variant