### PR TITLE
Allow dynamic values for use-clipboard action

### DIFF
--- a/packages/svelteui-composables/src/actions/use-clipboard/use-clipboard.ts
+++ b/packages/svelteui-composables/src/actions/use-clipboard/use-clipboard.ts
@@ -6,16 +6,23 @@ import type { Action } from '../../shared/actions/types';
  * ```tsx
  *  <button use:clipboard={'This text will be copied'}>Copy Me</button>
  * ```
+ * or
+ *
+ * ```tsx
+ *  <button use:clipboard={() => `This text will be copied at ${new Date().toUTCString()}`}>Copy Me</button>
+ * ```
+ *
  * @param text - The text that you want to be copied when the DOM element is clicked
  * @see https://svelteui.org/actions/use-clipboard
  */
-export function clipboard(node: HTMLElement, text: string): ReturnType<Action> {
+export function clipboard(node: HTMLElement, text: string | (() => string)): ReturnType<Action> {
 	const click = async () => {
-		if (text)
+		const detailText = typeof text === 'function' ? text() : text;
+		if (detailText)
 			try {
-				await navigator.clipboard.writeText(text);
+				await navigator.clipboard.writeText(detailText);
 
-				node.dispatchEvent(new CustomEvent('useclipboard', { detail: text }));
+				node.dispatchEvent(new CustomEvent('useclipboard', { detail: detailText }));
 			} catch (e) {
 				node.dispatchEvent(new CustomEvent('useclipboard-error', { detail: e }));
 			}
@@ -24,7 +31,7 @@ export function clipboard(node: HTMLElement, text: string): ReturnType<Action> {
 	node.addEventListener('click', click, true);
 
 	return {
-		update: (t: string) => (text = t),
+		update: (t: string | (() => string)) => (text = t),
 		destroy: () => node.removeEventListener('click', click, true)
 	};
 }

--- a/packages/svelteui-composables/test/actions/components/use-clipboard.svelte
+++ b/packages/svelteui-composables/test/actions/components/use-clipboard.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { clipboard } from '$clib/actions/use-clipboard/use-clipboard';
 
-	export let text = 'This text will be copied';
+	export let text: string | (() => string) = 'This text will be copied';
 	export let callback;
 	export let callbackError;
 </script>


### PR DESCRIPTION
## Description

Implementation for #348 allowing to set the clipboard text to a function, which is evaluated on click

```tsx
 <button use:clipboard={() => `This text will be copied at ${new Date().toUTCString()}`}>Copy Me</button>
```

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [x] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [x] Include a description of the changes made in the PR description and in the commit messages.
- [ ] Include screenshots/videos of the changes made.
- [x] Verify that the linter and tests are passing, with `yarn lint` and `yarn test` or just run `yarn prepush`.
