### PR TITLE
[docs]: add disabled option to NativeSelect sample

### DIFF
--- a/packages/svelteui-demos/src/demos/core/NativeSelect/NativeSelect.demo.objects.svelte
+++ b/packages/svelteui-demos/src/demos/core/NativeSelect/NativeSelect.demo.objects.svelte
@@ -10,6 +10,7 @@
       { label: 'Svelte', value: 'svelte' },
       { label: 'Vue', value: 'vue' },
       { label: 'Angular', value: 'angular' },
+      { label: 'JQuery', value: 'jquery', disabled: true },
       { label: 'React', value: 'react' }
     ]}
     placeholder="Pick one"
@@ -32,6 +33,7 @@
 		{ label: 'Svelte', value: 'svelte' },
 		{ label: 'Vue', value: 'vue' },
 		{ label: 'Angular', value: 'angular' },
+		{ label: 'JQuery', value: 'jquery', disabled: true },
 		{ label: 'React', value: 'react' }
 	]}
 	placeholder="Pick one"


### PR DESCRIPTION
## Description

Added a disabled option to the NativeSelect example.
Closes #381 

![image](https://github.com/svelteuidev/svelteui/assets/6402969/b049f70a-bcf5-4970-a161-b547fb523aed)
![image](https://github.com/svelteuidev/svelteui/assets/6402969/3e0e4341-0837-46b2-bf81-9975869dcbb0)

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [x] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [x] Include a description of the changes made in the PR description and in the commit messages.
- [x] Include screenshots/videos of the changes made.
- [x] Verify that the linter and tests are passing, with `yarn lint` and `yarn test` or just run `yarn prepush`.
