### PR TITLE
[@svelteui/core]: add Switch innerLabelSize property

### DIFF
--- a/apps/docs/src/routes/core/switch/+page.md
+++ b/apps/docs/src/routes/core/switch/+page.md
@@ -32,7 +32,7 @@ Switch component is used to enable/disable something, normally used for boolean 
 
 There is support for inserting text inside the switch for when it is enabled and/or disabled. It is also possible to control the size of the switch with predefined values: `xs`, `sm`, `md`, `lg`, `xl`.
 
-This inner label size can be overridden using the `innerLabelSize` property.
+This inner label size can be overridden using the `insideLabelSize` property.
 
 <Demo demo={SwitchDemos.inner} />
 

--- a/apps/docs/src/routes/core/switch/+page.md
+++ b/apps/docs/src/routes/core/switch/+page.md
@@ -32,6 +32,8 @@ Switch component is used to enable/disable something, normally used for boolean 
 
 There is support for inserting text inside the switch for when it is enabled and/or disabled. It is also possible to control the size of the switch with predefined values: `xs`, `sm`, `md`, `lg`, `xl`.
 
+This inner label size can be overridden using the `innerLabelSize` property.
+
 <Demo demo={SwitchDemos.inner} />
 
 ## Accessibility

--- a/packages/svelteui-core/src/components/Switch/Switch.d.ts
+++ b/packages/svelteui-core/src/components/Switch/Switch.d.ts
@@ -16,6 +16,7 @@ export interface SwitchProps
 	color?: SvelteUIColor;
 	size?: SvelteUINumberSize;
 	radius?: SvelteUINumberSize;
+	insideLabelSize?: SvelteUINumberSize;
 	transitionFunction?: SwitchTimingFunction;
 	className?: string;
 	id?: string;

--- a/packages/svelteui-core/src/components/Switch/Switch.stories.svelte
+++ b/packages/svelteui-core/src/components/Switch/Switch.stories.svelte
@@ -14,3 +14,15 @@
 <Story name="Disabled" id="switchDisabledStory">
 	<Switch disabled />
 </Story>
+
+<Story
+	name="With label"
+	id="switchLabelStory"
+	args={{ label: 'I would like to receive annoying notifications ' }}
+/>
+
+<Story
+	name="With inside label"
+	id="switchInsideLabelStory"
+	args={{ size: 'md', onLabel: 'ON', offLabel: 'OFF' }}
+/>

--- a/packages/svelteui-core/src/components/Switch/Switch.styles.ts
+++ b/packages/svelteui-core/src/components/Switch/Switch.styles.ts
@@ -154,7 +154,7 @@ export default createStyles(
 					},
 
 					'&::after': {
-						transform: 'translateX(-200%)',
+						left: '10%',
 						content: onLabel ? `'${onLabel}'` : "''",
 						color: 'White'
 					}

--- a/packages/svelteui-core/src/components/Switch/Switch.styles.ts
+++ b/packages/svelteui-core/src/components/Switch/Switch.styles.ts
@@ -6,6 +6,7 @@ export interface SwitchStyleParams {
 	color: SvelteUIColor;
 	radius: SvelteUINumberSize;
 	size: SvelteUINumberSize;
+	insideLabelSize: SvelteUINumberSize;
 	transitionFunction: SwitchTimingFunction;
 	onLabel: string;
 	offLabel: string;
@@ -58,7 +59,18 @@ export const sizes = {
 };
 
 export default createStyles(
-	(theme, { radius, size, transitionFunction, color, offLabel, onLabel }: SwitchStyleParams) => {
+	(
+		theme,
+		{
+			radius,
+			size,
+			transitionFunction,
+			color,
+			offLabel,
+			onLabel,
+			insideLabelSize
+		}: SwitchStyleParams
+	) => {
 		return {
 			root: {
 				display: 'flex',
@@ -83,7 +95,7 @@ export default createStyles(
 				appearance: 'none',
 				display: 'flex',
 				alignItems: 'center',
-				fontSize: sizes[size].insideLabelFont,
+				fontSize: insideLabelSize || sizes[size].insideLabelFont,
 				fontWeight: 600,
 
 				[`${dark.selector} &`]: {

--- a/packages/svelteui-core/src/components/Switch/Switch.svelte
+++ b/packages/svelteui-core/src/components/Switch/Switch.svelte
@@ -14,6 +14,7 @@
 		color: $$Props['color'] = 'blue',
 		size: $$Props['size'] = 'sm',
 		radius: $$Props['radius'] = 'xl',
+		insideLabelSize: $$Props['insideLabelSize'] = undefined,
 		transitionFunction: $$Props['transitionFunction'] = 'linear',
 		id: $$Props['id'] = randomID(),
 		label: $$Props['label'] = '',
@@ -31,6 +32,7 @@
 			color,
 			offLabel,
 			onLabel,
+			insideLabelSize,
 			radius,
 			size,
 			transitionFunction


### PR DESCRIPTION
## Description
While using inner labels (`onLabel` and `offLabel`) for the Switch component, I noticed that text was often moved further out of frame the longer it was, and that the size of font was unsuitable for emojies:

![image](https://github.com/svelteuidev/svelteui/assets/30713944/a481f5c2-e574-4c0b-af5f-595712593483)
![image](https://github.com/svelteuidev/svelteui/assets/30713944/941b5dc7-5b06-46ab-aa3b-0d88db661493)

To fix this I added a new property to override `onLabel` and `offLabel` sizes called `innerLabelSize`. I also changed the `onLabel` CSS from `transform: translateX(-200%)` to `left: 10%` which mirrors the `offLabel` CSS of `right: 10%`.

![image](https://github.com/svelteuidev/svelteui/assets/30713944/27a8f4d5-f575-4a64-9adb-a2d010b80a77)
![image](https://github.com/svelteuidev/svelteui/assets/30713944/097b260b-daa6-40ed-b85a-c699f0a02ec9)

Would love some feedback as my first contribution to this repo. Not too fussed if it's not suitable; it fixes my issue and thought I would share.

### Before submitting the PR, please make sure you do the following
* [x]  Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
* [x]  Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
* [x]  Include a description of the changes made in the PR description and in the commit messages.
* [x]  Include screenshots/videos of the changes made.
* [x]  Verify that the linter and tests are passing, with `yarn lint` and `yarn test` or just run `yarn prepush`.