### PR TITLE
[docs]: fix PasswordInput import

### DIFF
--- a/packages/svelteui-demos/src/demos/core/PasswordInput/PasswordInput.demo.icon.svelte
+++ b/packages/svelteui-demos/src/demos/core/PasswordInput/PasswordInput.demo.icon.svelte
@@ -3,7 +3,7 @@
 
 	const code = `
 <script>
-  import { TextInput } from '@svelteuidev/core';
+  import { PasswordInput } from '@svelteuidev/core';
   import { LockClosed } from 'radix-icons-svelte';
 <\/script>
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

Before submitting a PR, please read https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md

1. Give the PR a descriptive title
2. Ensure there is a related issue and it is referenced in the PR text
3. Ensure there are tests that cover the changes
4. Ensure that `yarn prepush` passes.

Happy contributing!

-->

## Description

<!--
Please write here a description of what this Pull Request added/changed.
Feel free to add screenshots/videos that illustrate the changes made.
-->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [x] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [x] Include a description of the changes made in the PR description and in the commit messages.
- [x] Include screenshots/videos of the changes made.
- [x] Verify that the linter and tests are passing, with `yarn lint` and `yarn test` or just run `yarn prepush`.

I'm using PasswordInput component on my project when I saw this wrong import. I love SvelteUI and this is my first time contributing to open source ^_^.

![image](https://github.com/svelteuidev/svelteui/assets/16535340/d626a9bf-4553-4ee1-997e-b5fd12fc0100)

```yarn prepush```
![image](https://github.com/svelteuidev/svelteui/assets/16535340/5f4eb973-3b09-499e-9348-bcdfa36c94ce)

