### PR TITLE
[@svelteui/core] fix: add missing fontFamily to Checkbox.label

### DIFF
--- a/packages/svelteui-core/src/components/Checkbox/Checkbox.styles.ts
+++ b/packages/svelteui-core/src/components/Checkbox/Checkbox.styles.ts
@@ -45,6 +45,7 @@ export default createStyles(
 				fontSize: `$${size}`,
 				lineHeight: `$${size}`,
 				color: '#000000',
+				fontFamily: theme.fonts.standard.value ?? 'sans-serif',
 				darkMode: {
 					color: '$dark000'
 				}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

Before submitting a PR, please read https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md

1. Give the PR a descriptive title
2. Ensure there is a related issue and it is referenced in the PR text
3. Ensure there are tests that cover the changes
4. Ensure that `yarn prepush` passes.

Happy contributing!

-->

## Description

I fixed Checkbox label fontFamily styling (Partial fix of #441) based on 00649e3de077c1771b52612edd30fd79be5c5e31 

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing guide](https://github.com/svelteuidev/svelteui/blob/main/CONTRIBUTING.md)
- [x] Prefix your PR title with `[@svelteui/core]`, `[@svelteui/actions]`, `[@svelteui/motion]`, `[@svelteui/core]`, `[core]`, or `[docs]`.
- [x] Include a description of the changes made in the PR description and in the commit messages.
- [ ] Include screenshots/videos of the changes made.
- [ ] Verify that the linter and tests are passing, with `yarn lint` and `yarn test` or just run `yarn prepush`.

### Unrelated

But the previous section in the template has `[@svelteui/core]` twice