### PR TITLE
[docs] Updates to Text LineClamp

### DIFF
--- a/apps/docs/src/routes/core/text/+page.md
+++ b/apps/docs/src/routes/core/text/+page.md
@@ -61,6 +61,8 @@ Specify maximum amount of lines with `lineClamp` prop. This option uses [-webkit
 
 <Demo demo={TextDemos.clamp} />
 
+- `lineClamp={0}` will show all the associated text.
+
 ## Inherit Styles
 
 Text always applies font-size, font-family and line-height styles, but in some cases this is not a desired behavior. To force Text to inherit parent styles set `inherit` prop. For example, highlight part of [Title]({base}/core/title):

--- a/packages/svelteui-demos/src/demos/core/Text/Text.demo.clamp.svelte
+++ b/packages/svelteui-demos/src/demos/core/Text/Text.demo.clamp.svelte
@@ -16,7 +16,7 @@
 		codeTemplate,
 		configurator: [
 			{ name: 'size', type: 'size', initialValue: 'md', defaultValue: 'md' },
-			{ name: 'lineClamp', label: 'Line clamp', type: 'number', initialValue: 4, min: 1, max: 5 }
+			{ name: 'lineClamp', label: 'Line clamp', type: 'number', initialValue: 4, min: 0, max: 5 }
 		]
 	};
 </script>


### PR DESCRIPTION
This is a simple revision that adds to the `lineClamp` attribute of the `<Text>` element. The attribute can be set to a value of zero which will display all text. This is a useful option for users that may want to toggle the value.

For Example:
```
<script>
let lineClamp = 1;
</script>

<Text lineClamp={lineClamp} on:click={() => lineClamp = lineClamp === 1 ? 0 : 1}>
  My text goes here...
</Text>
```

It makes two simple changes:

- adds a short description to the elements' documentation, and 
- modifies the demo range to allow for the value of `0`.

Associated issue: #510 